### PR TITLE
Add package-level Javadoc and link Javadoc from doc-site nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - Home: index.md
   - Guide & quickstart: 00-guide.md
   - API reference: 01-api-reference.md
+  - Javadoc: https://j.omnist.dev/javadoc/
   - CLI reference: 02-cli-reference.md
   - Status & limitations: limitations.md
   - Workflow playbook: workflow-playbook.md

--- a/src/main/java/dev/omnist/algebra/package-info.java
+++ b/src/main/java/dev/omnist/algebra/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * The normative Schema Algebra: operations that reason about and transform an
+ * OSD {@link dev.omnist.schema.Schema} itself, rather than the documents it
+ * describes — {@code normalize}, {@code prune}, {@code extract}, {@code lint},
+ * {@code compatible_with}, {@code equivalent}, {@code is_empty}, and structural
+ * inference from sample documents (omnist-spec §6).
+ */
+package dev.omnist.algebra;

--- a/src/main/java/dev/omnist/cli/package-info.java
+++ b/src/main/java/dev/omnist/cli/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * The {@code omnist} command-line interface: parses arguments and dispatches to
+ * every subcommand ({@code format}, {@code validate}, {@code convert},
+ * {@code schema normalize/prune/extract/lint/compatible-with/equivalent/is-empty},
+ * {@code infer}) documented in {@code docs/02-cli-reference.md}, wiring the codec,
+ * schema, and validation packages together into the tool end users run.
+ */
+package dev.omnist.cli;

--- a/src/main/java/dev/omnist/codec/package-info.java
+++ b/src/main/java/dev/omnist/codec/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Reading and writing the {@link dev.omnist.document.Document} model as the
+ * non-OML wire formats — JSON, YAML, TOML, and XML (omnist-spec §7.3) — including
+ * the lossy-adjustment reporting ({@link dev.omnist.codec.WriteReport}) that
+ * records when a format's constraints force a value to be adjusted on write.
+ */
+package dev.omnist.codec;

--- a/src/main/java/dev/omnist/conformance/package-info.java
+++ b/src/main/java/dev/omnist/conformance/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * The omnist-spec conformance test harness: runs Track 1 (CLI fixtures) and
+ * Track 2 (JSON vectors) from the vendored spec fixtures against this
+ * implementation's CLI, verifying it matches the spec's documented behavior
+ * (omnist-spec §8.5). Excluded from the JaCoCo coverage gate — its job is to
+ * drive external test infrastructure, not logic the unit suite exercises.
+ */
+package dev.omnist.conformance;

--- a/src/main/java/dev/omnist/oml/package-info.java
+++ b/src/main/java/dev/omnist/oml/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * The lexer and parser for OML, Omnist's canonical text format (omnist-spec §4)
+ * — the format every other codec's input is normalized through and every
+ * {@code omnist format} output is written in.
+ */
+package dev.omnist.oml;

--- a/src/main/java/dev/omnist/schema/package-info.java
+++ b/src/main/java/dev/omnist/schema/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * OSD (Omnist Schema Definition) modeling and I/O: the {@link dev.omnist.schema.Schema}
+ * type model — records, fields, scalar kinds — plus the lexer, parser, and writer
+ * that read and write schemas in their canonical text form (omnist-spec §5).
+ */
+package dev.omnist.schema;

--- a/src/main/java/dev/omnist/validation/package-info.java
+++ b/src/main/java/dev/omnist/validation/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Validating and materializing documents against an OSD schema: checking a
+ * {@link dev.omnist.document.Document} conforms to a {@link dev.omnist.schema.Schema}
+ * and reporting diagnostics when it doesn't (omnist-spec §3.6), and the
+ * materialization pass that produces a schema-conformant document from one
+ * that's structurally compatible but not yet exact (§6.3, §8.2).
+ */
+package dev.omnist.validation;


### PR DESCRIPTION
## Summary
- Adds `package-info.java` to the 7 packages that had none (`algebra`, `cli`, `codec`, `conformance`, `oml`, `schema`, `validation`), each citing the relevant omnist-spec section, matching `dev.omnist.document`'s existing style
- `dev.omnist.util` was excluded — it's an empty directory with zero `.java` files, not a real package; flagged separately for cleanup rather than documented
- Adds a `Javadoc: https://j.omnist.dev/javadoc/` entry to `mkdocs.yml`'s nav so the generated Javadoc is actually reachable from the doc site instead of only by typing the URL directly

Closes #30.

## Test plan
- [x] `mvn -q clean test` — exit 0
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0
- [x] `mvn org.apache.maven.plugins:maven-javadoc-plugin:3.10.0:javadoc -Dquiet=false` — exit 0, all 7 package-summary pages show real descriptions, zero new warnings
- [x] `mkdocs build --strict` — clean, Javadoc nav entry confirmed present in built `site/index.html`
- [ ] After merge, confirm the live nav shows the Javadoc entry at https://j.omnist.dev/ once the docs workflow redeploys
