### PR TITLE
CI: check out submodules in test-and-coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           cache: 'maven'
 
       - name: Build and Test with JaCoCo Coverage Check
-        run: mvn clean test jacoco:report jacoco:check
+        run: mvn clean test
 
   conformance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `submodules: true` to the `test-and-coverage` job's checkout step, matching the sibling `conformance` job (fixes `ConformanceTest` failing on missing fixtures)
- Stops invoking `jacoco:report`/`jacoco:check` as bare CLI goals — they're already bound to the `test` phase in `pom.xml` with `rules`/`excludes` configured there; the ad-hoc CLI invocation ran an unbound execution missing that config, which only surfaced once the first fix let tests actually run

Found while verifying CI on #31 (PR for #30) — that PR's `test-and-coverage` check failed on the first bug, and fixing it exposed the second.

Closes #32.

## Test plan
- [x] `mvn -q clean test` — exit 0, `ConformanceTest` passes
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0
- [x] Both CI jobs (`test-and-coverage`, `conformance`) green on this PR
