### PR TITLE
Coverage: fix 2 false negatives + 1 real dead branch, document rest (part of #34)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,18 +118,30 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <!-- 99.65% measured 2026-08-15 (excl. dev.omnist.conformance),
-                                                 after closing SchemaAlgebra's remaining gaps; gate set just
-                                                 below the real achieved number so it catches actual
-                                                 regressions immediately rather than sitting on a stale
-                                                 floor from an earlier, lower-coverage baseline. -->
-                                            <minimum>0.996</minimum>
+                                            <!-- 99.79% measured 2026-08-16 (excl. dev.omnist.conformance), after
+                                                 #34's investigation: the only 6 remaining gate-scoped missed lines
+                                                 are all confirmed-unreachable defensive code (regex/DOM/Jackson
+                                                 contract guarantees; see comments at OmlLexer's two
+                                                 NumberFormatException catches, XmlCodec.read's null-root check,
+                                                 and JsonCodec.write's IOException catch); JaCoCo has no
+                                                 line-level exclusion mechanism (only class-level, already used
+                                                 for dev.omnist.conformance/CliMain above), so these stay
+                                                 inline rather than being fragmented into dedicated excluded
+                                                 classes purely to chase the metric. Gate set just below the
+                                                 real achieved number so it catches actual regressions
+                                                 immediately rather than sitting on a stale floor. -->
+                                            <minimum>0.997</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <!-- 97.87% measured 2026-08-15 (excl. dev.omnist.conformance) -->
-                                            <minimum>0.978</minimum>
+                                            <!-- 97.96% measured 2026-08-16 (excl. dev.omnist.conformance). #34
+                                                 also tracks closing the remaining ~40 branch-only gaps, which
+                                                 need per-site investigation (some are likely reachable with a
+                                                 crafted test, per the OmlLexer/XmlCodec character-class and
+                                                 attribute-handling patterns; some may turn out equally
+                                                 unreachable); not yet done as of this measurement. -->
+                                            <minimum>0.979</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/src/main/java/dev/omnist/algebra/SchemaAlgebra.java
+++ b/src/main/java/dev/omnist/algebra/SchemaAlgebra.java
@@ -344,19 +344,13 @@ public final class SchemaAlgebra {
         stack.push(schema.root());
         while (!stack.isEmpty()) {
             String name = stack.pop();
-            if (seen.contains(name) || !schema.records().containsKey(name)) {
-                // JaCoCo artifact: manually traced this exact algorithm against a
-                // self-referencing schema and confirmed the continue is reached
-                // (seenContains=true on the second pop); the enclosing if's own
-                // compound-branch coverage also shows the true path taken. The
-                // bare continue's GOTO bytecode just doesn't register a hit.
-                continue;
-            }
-            seen.add(name);
-            Record rec = schema.records().get(name);
-            for (Field f : rec.fields()) {
-                if (f.type() instanceof Type.Ref ref) {
-                    stack.push(ref.name());
+            if (!seen.contains(name) && schema.records().containsKey(name)) {
+                seen.add(name);
+                Record rec = schema.records().get(name);
+                for (Field f : rec.fields()) {
+                    if (f.type() instanceof Type.Ref ref) {
+                        stack.push(ref.name());
+                    }
                 }
             }
         }
@@ -789,26 +783,21 @@ public final class SchemaAlgebra {
 
         while (!stack.isEmpty()) {
             String name = stack.pop();
-            if (seen.contains(name) || !schema.records().containsKey(name)) {
-                // JaCoCo artifact, same as reachablePlain's twin continue above: the
-                // enclosing self-cycle test (testPruneOptionalRefToUnsatisfiableAndCycles)
-                // pushes "Root" twice via the self-ref field, so this is genuinely reached
-                // on the second pop; the bare continue's GOTO just doesn't register a hit.
-                continue;
-            }
-            seen.add(name);
-            Record rec = schema.records().get(name);
+            if (!seen.contains(name) && schema.records().containsKey(name)) {
+                seen.add(name);
+                Record rec = schema.records().get(name);
 
-            List<Field> fieldsToFollow;
-            if (!rootOk && name.equals(schema.root())) {
-                fieldsToFollow = rec.fields();
-            } else {
-                fieldsToFollow = pruneRecord(rec, sat).fields();
-            }
+                List<Field> fieldsToFollow;
+                if (!rootOk && name.equals(schema.root())) {
+                    fieldsToFollow = rec.fields();
+                } else {
+                    fieldsToFollow = pruneRecord(rec, sat).fields();
+                }
 
-            for (Field f : fieldsToFollow) {
-                if (f.type() instanceof Type.Ref ref) {
-                    stack.push(ref.name());
+                for (Field f : fieldsToFollow) {
+                    if (f.type() instanceof Type.Ref ref) {
+                        stack.push(ref.name());
+                    }
                 }
             }
         }

--- a/src/main/java/dev/omnist/codec/TomlCodec.java
+++ b/src/main/java/dev/omnist/codec/TomlCodec.java
@@ -101,28 +101,26 @@ public final class TomlCodec {
             } else {
                 char c = text.charAt(i);
                 if ((c >= '0' && c <= '9') || c == '+' || c == '-') {
+                    // c is a digit, '+', or '-', all of which satisfy isTokenChar, so
+                    // the loop below always advances past `start` at least once --
+                    // there's no i == start case to guard against.
                     int start = i;
                     while (i < n && isTokenChar(text.charAt(i))) {
                         i++;
                     }
-                    if (i == start) {
-                        sb.append(c);
-                        i++;
-                    } else {
-                        String token = text.substring(start, i);
-                        if (isHex(token) || isOctal(token) || isBinary(token) || isDecimal(token)) {
-                            int digitCount = countDigits(token);
-                            if (digitCount > 4300) {
-                                throw new RuntimeException("Integer exceeds maximum digit limit of 4300");
-                            }
-                            if (digitCount > 18) {
-                                sb.append("\"__omnist_int__").append(token).append("\"");
-                            } else {
-                                sb.append(token);
-                            }
+                    String token = text.substring(start, i);
+                    if (isHex(token) || isOctal(token) || isBinary(token) || isDecimal(token)) {
+                        int digitCount = countDigits(token);
+                        if (digitCount > 4300) {
+                            throw new RuntimeException("Integer exceeds maximum digit limit of 4300");
+                        }
+                        if (digitCount > 18) {
+                            sb.append("\"__omnist_int__").append(token).append("\"");
                         } else {
                             sb.append(token);
                         }
+                    } else {
+                        sb.append(token);
                     }
                 } else {
                     sb.append(c);

--- a/src/main/java/dev/omnist/codec/XmlCodec.java
+++ b/src/main/java/dev/omnist/codec/XmlCodec.java
@@ -103,7 +103,10 @@ public final class XmlCodec {
             InputSource is = new InputSource(new StringReader(text));
             org.w3c.dom.Document domDoc = dbf.newDocumentBuilder().parse(is);
             rootElem = domDoc.getDocumentElement();
-            // Defensive: getDocumentElement() rarely returns null for valid XML documents
+            // Unreachable in practice: DocumentBuilder.parse() either throws (malformed
+            // input, caught below) or returns a Document per the well-formedness
+            // contract, which always has exactly one root element -- there's no real
+            // input that reaches this line with a null rootElem.
             if (rootElem == null) {
                 throw new RuntimeException("no document element found");
             }

--- a/src/main/java/dev/omnist/oml/OmlLexer.java
+++ b/src/main/java/dev/omnist/oml/OmlLexer.java
@@ -243,7 +243,12 @@ public class OmlLexer {
                 double d = Double.parseDouble(text);
                 advance(text.length());
                 return new Token(TokenType.NUMBER, text, d, startLine, startCol);
-            } catch (NumberFormatException ignored) {}
+            } catch (NumberFormatException ignored) {
+                // Unreachable in practice: every string NUMBER_PATTERN can match is
+                // -?\d+\.\d+([eE][-+]?\d+)? or -?\d+[eE][-+]?\d+, both of which are
+                // strict subsets of Double.parseDouble's grammar and never overflow
+                // into an exception (only into Infinity/0, neither of which throws).
+            }
         }
 
         // Rule 7: Reserved float spellings nan, inf, -inf (emitted as NUMBER)
@@ -273,6 +278,11 @@ public class OmlLexer {
                 advance(text.length());
                 return new Token(TokenType.INTEGER, text, bi, startLine, startCol);
             } catch (NumberFormatException e) {
+                // Unreachable in practice: every string INTEGER_PATTERN (-?\d+) can
+                // match is exactly BigInteger(String)'s accepted grammar, so this
+                // catch can't actually fire. Kept as defensive handling for the
+                // checked-exception-shaped contract, same as JsonCodec.write's
+                // IOException catch below.
                 throw error("parse.unexpected-token", "Invalid integer literal: " + text, startLine, startCol);
             }
         }


### PR DESCRIPTION
## Summary

Partial progress on #34. Regenerated the gate-scoped coverage gap list
(`mvn org.jacoco:jacoco-maven-plugin:0.8.12:report`, read `jacoco.xml`
directly) and investigated every remaining gap:

- **Fixed 2 real false negatives**: `SchemaAlgebra`'s two "JaCoCo artifact"
  bare-`continue` lines were already documented as reached-but-miscounted.
  Restructuring both loops as a positive-condition `if` block instead of a
  negated guard + `continue` produces bytecode JaCoCo counts correctly —
  confirmed by rerunning coverage, both lines now register as covered
  with no test changes.
- **Fixed 1 real dead branch**: `TomlCodec`'s `if (i == start)` was
  provably unreachable — every character that reaches it (digit, `+`,
  `-`) already satisfies `isTokenChar`, so the scan loop always advances
  past `start`. Removed the impossible branch.
- **Confirmed 6 remaining LINE gaps are genuinely unreachable** (not just
  unobserved), each against its actual dependency's contract: `OmlLexer`'s
  two `NumberFormatException` catches (regex output is a strict subset of
  `Double.parseDouble`/`BigInteger`'s accepted grammar), `XmlCodec`'s
  null-root check (`org.w3c.dom`'s well-formedness contract guarantees a
  root element), and `JsonCodec`'s `IOException` catch (Jackson never
  throws on this codec's own controlled type graph — already documented
  before this PR). Added/kept in-place comments explaining each.
- **Investigated JaCoCo's exclusion granularity**: confirmed it has no
  line-level exclusion mechanism (only class-level, already used here for
  `dev.omnist.conformance`/`CliMain`). Fragmenting these single defensive
  lines into dedicated excluded classes to hit literal 100% would trade
  readability for the metric, so they stay inline and documented — same
  choice already made for the two `continue` lines before this PR fixed
  those.
- Raised `pom.xml`'s LINE gate 99.6% → 99.7% to match the real, now-higher
  number.

**Not done — left as ongoing work under #34**: BRANCH coverage still has
~40 gate-scoped gaps (97.96%, gate nudged 97.8% → 97.9%). These need
per-site investigation the same way the LINE gaps got here; some look
plausibly reachable with a crafted test (character-class branches in
`OmlLexer`, attribute-handling branches in `XmlCodec`), others may turn
out equally dead. Scoping that as separate follow-up work rather than
rushing 40 individual verdicts in this pass.

## Test plan
- [x] `mvn -q clean test` — exit 0, gate passes at the raised thresholds
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0
- [x] `mvn javadoc:javadoc` — exit 0, no warnings
- [x] Confirmed via `jacoco.xml` diff that the 2 `SchemaAlgebra` lines now
      register as covered and the `TomlCodec` branch is gone, not just
      hidden
