### PR TITLE
Reject unterminated arrays instead of silently parsing them

### DIFF
--- a/src/main/java/dev/omnist/oml/OmlReader.java
+++ b/src/main/java/dev/omnist/oml/OmlReader.java
@@ -209,6 +209,7 @@ public class OmlReader {
         }
 
         boolean first = true;
+        boolean closed = false;
         while (peekType() != TokenType.EOF) {
             if (peekType() == TokenType.SEPARATOR) {
                 Token sep = peekToken();
@@ -216,6 +217,7 @@ public class OmlReader {
             }
             if (peekType() == TokenType.RBRACKET) {
                 consumeToken();
+                closed = true;
                 break;
             }
 
@@ -228,6 +230,7 @@ public class OmlReader {
                     }
                     if (peekType() == TokenType.RBRACKET) {
                         consumeToken();
+                        closed = true;
                         break;
                     }
                 } else {
@@ -261,6 +264,11 @@ public class OmlReader {
             }
 
             first = false;
+        }
+
+        if (!closed) {
+            Token eof = peekToken();
+            throw new OmlParseException(eof.line(), eof.col(), "parse.unexpected-token", "Expected ',' or ']' in array, got EOF");
         }
     }
 

--- a/src/test/java/dev/omnist/oml/OmlReaderTest.java
+++ b/src/test/java/dev/omnist/oml/OmlReaderTest.java
@@ -267,16 +267,13 @@ class OmlReaderTest {
     }
 
     @Test
-    @DisplayName("testCharacterization6_UnterminatedArrayReachesEofSilently: parseArrayElements' while-loop " +
-                 "condition is the only thing that stops it at EOF -- there's no explicit unterminated-array " +
-                 "error, so a missing closing ']' currently produces edges without ever signaling a parse " +
-                 "error. Characterizing existing behavior, not asserting it's the intended long-term contract " +
-                 "-- see the follow-up task filed for this codec's array-termination handling.")
-    void testCharacterization6_UnterminatedArrayReachesEofSilently() {
-        Document doc = OmlReader.read("a: [1, 2");
-        Node node = (Node) doc;
-        assertEquals(2, node.edges().size());
-        assertEquals(new Scalar.IntegerScalar(java.math.BigInteger.valueOf(1)), node.edges().get(0).target());
-        assertEquals(new Scalar.IntegerScalar(java.math.BigInteger.valueOf(2)), node.edges().get(1).target());
+    @DisplayName("unterminated array (EOF before closing ']') raises parse.unexpected-token (issue #37)")
+    void testUnterminatedArrayThrows() {
+        // Verified against the omni-spec grammar and all four sibling ports
+        // (Python/TS/Rust/Go), which all reject this input -- omnist-j was the
+        // only implementation silently parsing it as two top-level edges.
+        OmlParseException ex = assertThrows(OmlParseException.class, () -> OmlReader.read("a: [1, 2"));
+        assertEquals("parse.unexpected-token", ex.getCode());
+        assertTrue(ex.getMessage().contains("Expected ',' or ']' in array"));
     }
 }


### PR DESCRIPTION
## Summary
- `parseArrayElements` now raises `parse.unexpected-token` ("Expected ',' or ']' in array, got EOF") when an array's closing `]` is never reached, instead of silently parsing whatever elements it found as separate top-level edges
- Verified against the OML grammar (`RBRACKET` is mandatory in the `array` production) and all four sibling ports (Python/TS/Rust/Go), which all reject `"a: [1, 2"` — omnist-j was the only implementation with this gap
- A `closed` flag distinguishes "ran out of input mid-array" from the ordinary case where the array's `]` is legitimately the last token before EOF (e.g. `"b: [1, 2, 3]"` as the whole document) — an initial version without it broke that common case
- Updated the characterization test #36 added to capture today's (wrong) behavior to assert the new error instead

Closes #37.

## Test plan
- [x] `mvn -q clean test` — exit 0, gate passes
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0
