### PR TITLE
fix(xml): escape XML metacharacters in scalar text (#40)

### DIFF
--- a/src/main/java/dev/omnist/codec/XmlCodec.java
+++ b/src/main/java/dev/omnist/codec/XmlCodec.java
@@ -378,7 +378,20 @@ public final class XmlCodec {
     }
 
     private static String xmlSanitize(String text) {
-        return XML_ILLEGAL_CHAR.matcher(text).replaceAll("\uFFFD");
+        String clean = XML_ILLEGAL_CHAR.matcher(text).replaceAll("\uFFFD");
+        StringBuilder sb = new StringBuilder(clean.length() + 16);
+        for (int i = 0; i < clean.length(); i++) {
+            char c = clean.charAt(i);
+            switch (c) {
+                case '&' -> sb.append("&amp;");
+                case '<' -> sb.append("&lt;");
+                case '>' -> sb.append("&gt;");
+                case '"' -> sb.append("&quot;");
+                case '\'' -> sb.append("&apos;");
+                default -> sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 
     private static String xmlText(Object v) {

--- a/src/test/java/dev/omnist/codec/XmlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/XmlCodecTest.java
@@ -412,4 +412,29 @@ public class XmlCodecTest {
         String xml3 = XmlCodec.write(emptyLabel);
         assertTrue(xml3.contains("<_>") || xml3.contains("<_ "));
     }
+
+    @Test
+    @DisplayName("Issue #40: write escapes &, <, > in scalar text and does not inject markup")
+    void testXmlWriterEscapesMetacharacters() {
+        Node injectionDoc = new Node(List.of(new Edge("root", new StringScalar("<admin>true</admin>"))));
+        String xml = XmlCodec.write(injectionDoc);
+        assertTrue(xml.contains("&lt;admin&gt;true&lt;/admin&gt;"), "XML should contain escaped markup: " + xml);
+        assertFalse(xml.contains("<admin>"), "XML should not contain raw injected tag: " + xml);
+
+        Document roundtripped = XmlCodec.read(xml);
+        assertTrue(roundtripped instanceof Node);
+        Node roundNode = (Node) roundtripped;
+        assertEquals(1, roundNode.edges().size());
+        assertEquals("root", roundNode.edges().get(0).label());
+        assertEquals("<admin>true</admin>", ((StringScalar) roundNode.edges().get(0).target()).value());
+
+        // Adversarial metacharacters roundtrip
+        String adversarial = "<>&\"'\u0000\t\n<&amp;>";
+        Node advDoc = new Node(List.of(new Edge("root", new StringScalar(adversarial))));
+        String advXml = XmlCodec.write(advDoc);
+        Document advRound = XmlCodec.read(advXml);
+        // Note: \u0000 is replaced by \uFFFD by xmlSanitize
+        String expected = "<>&\"'\uFFFD\t\n<&amp;>";
+        assertEquals(expected, ((StringScalar) ((Node) advRound).edges().get(0).target()).value());
+    }
 }


### PR DESCRIPTION
Escapes &, <, >, ", ' in XmlCodec scalar text. Fixes #40.