### PR TITLE
fix(oml): quote digit-first and hyphen-first edge labels (#42)

### DIFF
--- a/src/main/java/dev/omnist/oml/OmlLexer.java
+++ b/src/main/java/dev/omnist/oml/OmlLexer.java
@@ -86,7 +86,7 @@ public class OmlLexer {
     private static final Pattern DATETIME_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(:\\d{2}(\\.\\d{1,6})?)?(Z|[-+]\\d{2}:\\d{2})?");
     private static final Pattern NUMBER_PATTERN = Pattern.compile("^-?\\d+\\.\\d+(?:[eE][-+]?\\d+)?|^-?\\d+[eE][-+]?\\d+");
     private static final Pattern INTEGER_PATTERN = Pattern.compile("^-?\\d+");
-    private static final Pattern IDENT_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+");
+    private static final Pattern IDENT_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_-]*");
 
     private final String source;
     private final Limits limits;

--- a/src/main/java/dev/omnist/oml/OmlWriter.java
+++ b/src/main/java/dev/omnist/oml/OmlWriter.java
@@ -13,7 +13,7 @@ public class OmlWriter {
 
     private OmlWriter() {}
 
-    private static final Pattern IDENT_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+$");
+    private static final Pattern IDENT_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_-]*$");
 
     /**
      * Serializes a {@link Document} to canonical indented OML text (omnist-spec §4 and §9.5).

--- a/src/test/java/dev/omnist/oml/OmlWriterTest.java
+++ b/src/test/java/dev/omnist/oml/OmlWriterTest.java
@@ -133,4 +133,41 @@ class OmlWriterTest {
         assertTrue(canonical.contains("{}"));
         assertEquals(doc, OmlReader.read(canonical));
     }
+
+    @Test
+    @DisplayName("Issue #42: labels starting with digits or hyphens write quoted and round-trip correctly")
+    void testDigitAndHyphenFirstLabelsWriteQuoted() {
+        List<String> labelsToTest = List.of("1abc", "-foo", "123", "-", "-1", "0", "0xyz", "_valid", "valid_1", "true", "nan", "inf", "null");
+        for (String label : labelsToTest) {
+            Node doc = new Node(List.of(new Edge(label, new Scalar.IntegerScalar(BigInteger.valueOf(42)))));
+            String written = OmlWriter.write(doc);
+            if (label.equals("_valid") || label.equals("valid_1")) {
+                assertTrue(written.contains(label + ": 42"), "Expected bare label for " + label + ", got: " + written);
+            } else {
+                assertTrue(written.contains("\"" + label + "\": 42"), "Expected quoted label for " + label + ", got: " + written);
+            }
+            Document roundtripped = OmlReader.read(written);
+            assertEquals(doc, roundtripped, "Round-trip failed for label: " + label);
+        }
+    }
+
+    @Test
+    @DisplayName("Property-style roundtrip test: read(write(doc)).equals(doc) over many label variations")
+    void testPropertyStyleLabelRoundTrip() {
+        String[] prefixes = {"", "a", "_", "1", "-", "Z", "9", "-a", "1_"};
+        String[] middles = {"", "abc", "123", "-_-", "true", "null", "nan", "inf", "false"};
+        String[] suffixes = {"", "x", "0", "_", "-", ":", " "};
+
+        for (String p : prefixes) {
+            for (String m : middles) {
+                for (String s : suffixes) {
+                    String label = p + m + s;
+                    Node doc = new Node(List.of(new Edge(label, new Scalar.StringScalar("val"))));
+                    String written = OmlWriter.write(doc);
+                    Document readBack = OmlReader.read(written);
+                    assertEquals(doc, readBack, "Round-trip failed for label: [" + label + "]");
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Aligns OML writer bare label predicate and lexer IDENT pattern with normative ABNF grammar (requiring letter or underscore first). Fixes #42.