### PR TITLE
fix(path): include [0] on first occurrence of repeated edge labels (#46)

### DIFF
--- a/src/main/java/dev/omnist/codec/JsonCodec.java
+++ b/src/main/java/dev/omnist/codec/JsonCodec.java
@@ -223,15 +223,14 @@ public final class JsonCodec {
             throw new WriteException("nesting exceeds the maximum depth (200)");
         }
         if (doc instanceof Node node) {
-            Map<String, Integer> counts = new HashMap<>();
+            Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(node);
+            Map<String, Integer> seen = new HashMap<>();
             for (Edge edge : node.edges()) {
                 String label = edge.label();
-                int i = counts.getOrDefault(label, 0);
-                counts.put(label, i + 1);
-                String p = path.equals("$") ? "$." + label : path + "." + label;
-                if (i > 0) {
-                    p = p + "[" + i + "]";
-                }
+                int i = seen.getOrDefault(label, 0);
+                seen.put(label, i + 1);
+                int total = totals.getOrDefault(label, 1);
+                String p = dev.omnist.document.PathUtils.childPath(path, label, i, total);
                 scanJson((Document) edge.target(), p, depth + 1, rep);
             }
         } else if (doc instanceof Scalar s) {

--- a/src/main/java/dev/omnist/codec/TomlCodec.java
+++ b/src/main/java/dev/omnist/codec/TomlCodec.java
@@ -608,15 +608,14 @@ public final class TomlCodec {
         }
         if (doc instanceof dev.omnist.document.Node node) {
             List<Edge> edges = new ArrayList<>();
-            Map<String, Integer> counts = new HashMap<>();
+            Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(node);
+            Map<String, Integer> seen = new HashMap<>();
             for (Edge edge : node.edges()) {
                 String label = edge.label();
-                int i = counts.getOrDefault(label, 0);
-                counts.put(label, i + 1);
-                String p = path.equals("$") ? "$." + label : path + "." + label;
-                if (i > 0) {
-                    p = p + "[" + i + "]";
-                }
+                int i = seen.getOrDefault(label, 0);
+                seen.put(label, i + 1);
+                int total = totals.getOrDefault(label, 1);
+                String p = dev.omnist.document.PathUtils.childPath(path, label, i, total);
                 Document child = (Document) edge.target();
                 if (child instanceof Value.NullValue) {
                     rep.add(p, "format.null-unrepresentable", "null value dropped (TOML has no null)", "warning");

--- a/src/main/java/dev/omnist/codec/XmlCodec.java
+++ b/src/main/java/dev/omnist/codec/XmlCodec.java
@@ -459,15 +459,14 @@ public final class XmlCodec {
                         "warning");
                 return;
             }
-            Map<String, Integer> counts = new HashMap<>();
+            Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(node);
+            Map<String, Integer> seen = new HashMap<>();
             for (Edge edge : node.edges()) {
                 String label = edge.label();
-                int i = counts.getOrDefault(label, 0);
-                counts.put(label, i + 1);
-                String p = path.equals("$") ? "$." + label : path + "." + label;
-                if (i > 0) {
-                    p = p + "[" + i + "]";
-                }
+                int i = seen.getOrDefault(label, 0);
+                seen.put(label, i + 1);
+                int total = totals.getOrDefault(label, 1);
+                String p = dev.omnist.document.PathUtils.childPath(path, label, i, total);
                 if (!XML_NAME.matcher(label).matches()) {
                     rep.add(p, "format.key-sanitized",
                             "label '" + label + "' isn't a valid XML name; written sanitized",

--- a/src/main/java/dev/omnist/codec/YamlCodec.java
+++ b/src/main/java/dev/omnist/codec/YamlCodec.java
@@ -300,18 +300,17 @@ public final class YamlCodec {
             throw new WriteException("nesting exceeds the maximum depth (200)");
         }
         if (doc instanceof dev.omnist.document.Node node) {
-            Map<String, Integer> counts = new HashMap<>();
+            Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(node);
+            Map<String, Integer> seen = new HashMap<>();
             for (Edge edge : node.edges()) {
                 String label = edge.label();
                 if (label.contains("\u0085")) {
                     rep.add(path, "format.string-line-break-char", "label contains U+0085 (NEL); written double-quoted to round-trip correctly", "warning");
                 }
-                int i = counts.getOrDefault(label, 0);
-                counts.put(label, i + 1);
-                String p = path.equals("$") ? "$." + label : path + "." + label;
-                if (i > 0) {
-                    p = p + "[" + i + "]";
-                }
+                int i = seen.getOrDefault(label, 0);
+                seen.put(label, i + 1);
+                int total = totals.getOrDefault(label, 1);
+                String p = dev.omnist.document.PathUtils.childPath(path, label, i, total);
                 scanYaml((Document) edge.target(), p, depth + 1, rep);
             }
         } else if (doc instanceof Scalar s) {

--- a/src/main/java/dev/omnist/document/PathUtils.java
+++ b/src/main/java/dev/omnist/document/PathUtils.java
@@ -1,0 +1,47 @@
+package dev.omnist.document;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Shared utilities for constructing canonical document paths in diagnostics and report adjustments (omnist-spec ?8).
+ */
+public final class PathUtils {
+
+    private PathUtils() {}
+
+    /**
+     * Precomputes the total occurrence counts for each label on a {@link Node}.
+     *
+     * @param node the node whose direct edges are counted
+     * @return a map from edge label to total count on this node
+     */
+    public static Map<String, Integer> countLabels(Node node) {
+        Map<String, Integer> counts = new HashMap<>();
+        for (Edge edge : node.edges()) {
+            counts.merge(edge.label(), 1, Integer::sum);
+        }
+        return counts;
+    }
+
+    /**
+     * Builds a canonical child path for an edge on a node.
+     *
+     * <p>When {@code totalCount > 1}, the 0-based index {@code [index]} is included on every occurrence,
+     * including the first (e.g. {@code $.item[0]}, {@code $.item[1]}).
+     * When {@code totalCount <= 1}, the index is omitted (e.g. {@code $.item}).
+     *
+     * @param parentPath the path to the parent node (e.g. {@code "$"} or {@code "$.user"})
+     * @param label      the edge label
+     * @param index      the 0-based occurrence index of this edge among edges with the same label on this node
+     * @param totalCount the total number of edges with this label on this node
+     * @return the canonical path string
+     */
+    public static String childPath(String parentPath, String label, int index, int totalCount) {
+        String base = parentPath.equals("$") ? "$." + label : (parentPath.isEmpty() ? label : parentPath + "." + label);
+        if (totalCount > 1) {
+            return base + "[" + index + "]";
+        }
+        return base;
+    }
+}

--- a/src/main/java/dev/omnist/validation/Materializer.java
+++ b/src/main/java/dev/omnist/validation/Materializer.java
@@ -99,14 +99,16 @@ public final class Materializer {
         }
 
         List<Edge> edges = new ArrayList<>();
-        Map<String, Integer> counts = new HashMap<>();
+        Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(n);
+        Map<String, Integer> seen = new HashMap<>();
 
         for (Edge edge : n.edges()) {
             String label = edge.label();
-            int i = counts.getOrDefault(label, 0);
-            counts.put(label, i + 1);
+            int i = seen.getOrDefault(label, 0);
+            seen.put(label, i + 1);
+            int total = totals.getOrDefault(label, 1);
 
-            String childPath = path + "." + label + (i > 0 ? "[" + i + "]" : "");
+            String childPath = dev.omnist.document.PathUtils.childPath(path, label, i, total);
             Field f = fieldMap.get(label);
 
             if (f == null) {
@@ -119,7 +121,7 @@ public final class Materializer {
         }
 
         for (Field f : record.fields()) {
-            int c = counts.getOrDefault(f.label(), 0);
+            int c = totals.getOrDefault(f.label(), 0);
             if (c < f.min() || (f.max() != null && c > f.max())) {
                 String boundStr = f.max() == null ? "unbounded" : String.valueOf(f.max());
                 diagnostics.add(new ValidationDiagnostic(path, "validate.cardinality",

--- a/src/main/java/dev/omnist/validation/Validator.java
+++ b/src/main/java/dev/omnist/validation/Validator.java
@@ -55,15 +55,17 @@ public class Validator {
             fieldMap.put(f.label(), f);
         }
 
-        Map<String, Integer> counts = new HashMap<>();
+        Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(node);
+        Map<String, Integer> seen = new HashMap<>();
 
         // 1. Closedness & Edge Matching in edge order (§3.6.1)
         for (Edge edge : node.edges()) {
             String label = edge.label();
-            int i = counts.getOrDefault(label, 0);
-            counts.put(label, i + 1);
+            int i = seen.getOrDefault(label, 0);
+            seen.put(label, i + 1);
+            int total = totals.getOrDefault(label, 1);
 
-            String childPath = path + "." + label + (i > 0 ? "[" + i + "]" : "");
+            String childPath = dev.omnist.document.PathUtils.childPath(path, label, i, total);
             Field f = fieldMap.get(label);
 
             if (f == null) {
@@ -76,7 +78,7 @@ public class Validator {
 
         // 2. Cardinality Check for all declared fields (§3.6)
         for (Field f : record.fields()) {
-            int c = counts.getOrDefault(f.label(), 0);
+            int c = totals.getOrDefault(f.label(), 0);
             if (c < f.min() || (f.max() != null && c > f.max())) {
                 String boundStr = f.max() == null ? "unbounded" : String.valueOf(f.max());
                 // Path is the parent node path (§3.6)

--- a/src/test/java/dev/omnist/document/PathUtilsTest.java
+++ b/src/test/java/dev/omnist/document/PathUtilsTest.java
@@ -1,0 +1,50 @@
+package dev.omnist.document;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PathUtilsTest {
+
+    @Test
+    @DisplayName("countLabels correctly tallies repeated and unique edge labels")
+    void testCountLabels() {
+        Node node = new Node(List.of(
+            new Edge("a", new Scalar.StringScalar("1")),
+            new Edge("b", new Scalar.StringScalar("2")),
+            new Edge("a", new Scalar.StringScalar("3")),
+            new Edge("a", new Scalar.StringScalar("4"))
+        ));
+
+        Map<String, Integer> counts = PathUtils.countLabels(node);
+        assertEquals(3, counts.get("a"));
+        assertEquals(1, counts.get("b"));
+    }
+
+    @Test
+    @DisplayName("childPath appends [index] for every occurrence when totalCount > 1, omits when totalCount <= 1")
+    void testChildPathFormatting() {
+        // Root path "$" with repeated label
+        assertEquals("$.item[0]", PathUtils.childPath("$", "item", 0, 2));
+        assertEquals("$.item[1]", PathUtils.childPath("$", "item", 1, 2));
+
+        // Root path "$" with single label
+        assertEquals("$.single", PathUtils.childPath("$", "single", 0, 1));
+
+        // Nested path "$.user" with repeated label
+        assertEquals("$.user.email[0]", PathUtils.childPath("$.user", "email", 0, 3));
+        assertEquals("$.user.email[1]", PathUtils.childPath("$.user", "email", 1, 3));
+        assertEquals("$.user.email[2]", PathUtils.childPath("$.user", "email", 2, 3));
+
+        // Nested path "$.user" with single label
+        assertEquals("$.user.name", PathUtils.childPath("$.user", "name", 0, 1));
+
+        // Empty parent path
+        assertEquals("item[0]", PathUtils.childPath("", "item", 0, 2));
+        assertEquals("item", PathUtils.childPath("", "item", 0, 1));
+    }
+}

--- a/src/test/java/dev/omnist/validation/ValidatorTest.java
+++ b/src/test/java/dev/omnist/validation/ValidatorTest.java
@@ -78,7 +78,7 @@ class ValidatorTest {
         assertFalse(res.isValid());
         assertEquals(3, res.diagnostics().size());
 
-        assertEquals("$.item", res.diagnostics().get(0).path(), "1st occurrence must have no bracket index");
+        assertEquals("$.item[0]", res.diagnostics().get(0).path(), "1st occurrence of repeated label must have [0] index");
         assertEquals("validate.type-mismatch", res.diagnostics().get(0).code());
 
         assertEquals("$.item[1]", res.diagnostics().get(1).path(), "2nd occurrence must have index [1]");


### PR DESCRIPTION
Centralizes path construction in PathUtils, ensuring 0-based indices [0], [1], ... are emitted on every occurrence of repeated labels across validation, materialization, and codec reports. Fixes #46.