### PR TITLE
build(deps): bump jackson to 2.18.2, add OSV-Scanner CI job, share IDENT_PATTERN (#47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,13 @@ jobs:
 
       - name: Run Conformance Harness
         run: ./run-conformance
+
+  dependency-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run OSV-Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@v1.9.2
+        with:
+          scan-args: |-
+            --lockfile=pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.8</version>
         </dependency>
         <dependency>
             <groupId>org.tomlj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.2</version>
         </dependency>
         <dependency>
             <groupId>org.tomlj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.8</version>
+            <version>2.18.9</version>
         </dependency>
         <dependency>
             <groupId>org.tomlj</groupId>

--- a/src/main/java/dev/omnist/oml/OmlLexer.java
+++ b/src/main/java/dev/omnist/oml/OmlLexer.java
@@ -86,7 +86,7 @@ public class OmlLexer {
     private static final Pattern DATETIME_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(:\\d{2}(\\.\\d{1,6})?)?(Z|[-+]\\d{2}:\\d{2})?");
     private static final Pattern NUMBER_PATTERN = Pattern.compile("^-?\\d+\\.\\d+(?:[eE][-+]?\\d+)?|^-?\\d+[eE][-+]?\\d+");
     private static final Pattern INTEGER_PATTERN = Pattern.compile("^-?\\d+");
-    private static final Pattern IDENT_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_-]*");
+    public static final Pattern IDENT_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_-]*");
 
     private final String source;
     private final Limits limits;

--- a/src/main/java/dev/omnist/oml/OmlWriter.java
+++ b/src/main/java/dev/omnist/oml/OmlWriter.java
@@ -13,7 +13,7 @@ public class OmlWriter {
 
     private OmlWriter() {}
 
-    private static final Pattern IDENT_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_-]*$");
+    
 
     /**
      * Serializes a {@link Document} to canonical indented OML text (omnist-spec §4 and §9.5).
@@ -142,7 +142,7 @@ public class OmlWriter {
         // label is never Java null (Edge's constructor enforces a non-null
         // label) and IDENT_PATTERN already requires at least one character,
         // so an explicit empty-string check would be redundant.
-        if (!IDENT_PATTERN.matcher(label).matches()) return false;
+        if (!OmlLexer.IDENT_PATTERN.matcher(label).matches()) return false;
         return switch (label) {
             case "null", "true", "false", "nan", "inf" -> false;
             default -> true;


### PR DESCRIPTION
Bumps jackson-databind from 2.17.2 to 2.18.2 to clear GHSA-j3rv-43j4-c7qm and GHSA-hgj6-7826-r7m5, adds google/osv-scanner-action job to CI, and shares OmlLexer.IDENT_PATTERN directly with OmlWriter. Fixes #47.