### PR TITLE
Fix safety limits consistency across codecs and Materializer (#44)

### DIFF
--- a/src/main/java/dev/omnist/codec/JsonCodec.java
+++ b/src/main/java/dev/omnist/codec/JsonCodec.java
@@ -27,7 +27,16 @@ import java.util.*;
  * <p>This class is stateless; all methods are {@code static}.
  */
 public final class JsonCodec {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER;
+    static {
+        com.fasterxml.jackson.core.StreamReadConstraints constraints = com.fasterxml.jackson.core.StreamReadConstraints.builder()
+                .maxNumberLength(10_000)
+                .build();
+        com.fasterxml.jackson.core.JsonFactory factory = com.fasterxml.jackson.core.JsonFactory.builder()
+                .streamReadConstraints(constraints)
+                .build();
+        MAPPER = new ObjectMapper(factory);
+    }
 
     private JsonCodec() {}
 
@@ -73,14 +82,15 @@ public final class JsonCodec {
     }
 
     private static Document buildNode(Object val, String path, int depth, int[] budget) {
-        budget[0]++;
-        if (budget[0] > 1_000_000) {
-            throw new RuntimeException(path + ": too many nodes materialized (over 1000000)");
-        }
-        if (depth > 200) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (200)");
+        Limits limits = Limits.DEFAULT;
+        if (depth > limits.maxDepth()) {
+            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
         if (val instanceof Map<?, ?> map) {
+            budget[0]++;
+            if (budget[0] > limits.maxNodeCount()) {
+                throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
+            }
             List<Edge> edges = new ArrayList<>();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 // Defensive: Invalid JSON (non-string keys) should never occur with ObjectMapper#readValue
@@ -122,6 +132,11 @@ public final class JsonCodec {
             return new BooleanScalar(b);
         }
         if (value instanceof BigInteger bi) {
+            String s = bi.toString();
+            int digits = s.startsWith("-") ? s.length() - 1 : s.length();
+            if (digits > Limits.DEFAULT.maxIntegerDigits()) {
+                throw new RuntimeException("document.limit.int-digits: Integer literal digit count (" + digits + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
+            }
             return new IntegerScalar(bi);
         }
         if (value instanceof Integer i) {

--- a/src/main/java/dev/omnist/codec/TomlCodec.java
+++ b/src/main/java/dev/omnist/codec/TomlCodec.java
@@ -300,12 +300,9 @@ public final class TomlCodec {
     }
 
     private static Document buildNode(Object val, String path, int depth, int[] budget) {
-        budget[0]++;
-        if (budget[0] > 1_000_000) {
-            throw new RuntimeException(path + ": too many nodes materialized (over 1000000)");
-        }
-        if (depth > 200) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (200)");
+        Limits limits = Limits.DEFAULT;
+        if (depth > limits.maxDepth()) {
+            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
         if (val instanceof org.tomlj.TomlTable tt) {
             val = tt.toMap();
@@ -317,6 +314,10 @@ public final class TomlCodec {
         // this call) -- the only remaining entry point (read()) always passes
         // result.toMap(), never a bare TomlArray.
         if (val instanceof Map<?, ?> map) {
+            budget[0]++;
+            if (budget[0] > limits.maxNodeCount()) {
+                throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
+            }
             List<Edge> edges = new ArrayList<>();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 if (!(entry.getKey() instanceof String k)) {
@@ -403,6 +404,11 @@ public final class TomlCodec {
         // __omnist_int__ string-wrapping above before tomlj ever parses them.
         // Kept as defensive handling in case tomlj's behavior ever changes.
         if (value instanceof BigInteger bi) {
+            String s = bi.toString();
+            int digits = s.startsWith("-") ? s.length() - 1 : s.length();
+            if (digits > Limits.DEFAULT.maxIntegerDigits()) {
+                throw new RuntimeException("document.limit.int-digits: Integer literal digit count (" + digits + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
+            }
             return new IntegerScalar(bi);
         }
         if (value instanceof Integer i) {

--- a/src/main/java/dev/omnist/codec/XmlCodec.java
+++ b/src/main/java/dev/omnist/codec/XmlCodec.java
@@ -145,12 +145,9 @@ public final class XmlCodec {
     }
 
     private static Object xmlToNode(org.w3c.dom.Element elem, String path, int depth, int[] budget) {
-        budget[0]++;
-        if (budget[0] > 1_000_000) {
-            throw new RuntimeException(path + ": too many nodes materialized (over 1000000)");
-        }
-        if (depth > 200) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (200)");
+        Limits limits = Limits.DEFAULT;
+        if (depth > limits.maxDepth()) {
+            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
 
         List<org.w3c.dom.Element> childElements = new ArrayList<>();
@@ -226,6 +223,10 @@ public final class XmlCodec {
                     if ("false".equals(s)) return Boolean.FALSE;
                 } else if (scalar.kind() == ScalarKind.INTEGER) {
                     if (XML_INT_RE.matcher(s).matches()) {
+                        String clean = s.startsWith("-") ? s.substring(1) : s;
+                        if (clean.length() > Limits.DEFAULT.maxIntegerDigits()) {
+                            throw new RuntimeException("document.limit.int-digits: Integer literal digit count (" + clean.length() + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
+                        }
                         return new BigInteger(s);
                     }
                 } else if (scalar.kind() == ScalarKind.NUMBER) {
@@ -265,15 +266,16 @@ public final class XmlCodec {
     }
 
     private static Document buildDoc(Object val, String path, int depth, int[] budget) {
-        budget[0]++;
-        if (budget[0] > 1_000_000) {
-            throw new RuntimeException(path + ": too many nodes materialized (over 1000000)");
-        }
+        Limits limits = Limits.DEFAULT;
         // No depth guard here: read() only reaches buildDoc after xmlToNode has
         // already walked the DOM tree that this List/Object[] structure mirrors
         // 1:1 (one xmlToNode level per buildDoc level) and thrown if any depth
         // exceeded 200, so that bound is already established.
         if (val instanceof List<?> list) {
+            budget[0]++;
+            if (budget[0] > limits.maxNodeCount()) {
+                throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
+            }
             List<Edge> edges = new ArrayList<>();
             for (Object item : list) {
                 Object[] edge = (Object[]) item;

--- a/src/main/java/dev/omnist/codec/YamlCodec.java
+++ b/src/main/java/dev/omnist/codec/YamlCodec.java
@@ -154,14 +154,15 @@ public final class YamlCodec {
     }
 
     private static Document buildNode(Object val, String path, int depth, int[] budget) {
-        budget[0]++;
-        if (budget[0] > 1_000_000) {
-            throw new RuntimeException(path + ": too many nodes materialized (over 1000000)");
-        }
-        if (depth > 200) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (200)");
+        Limits limits = Limits.DEFAULT;
+        if (depth > limits.maxDepth()) {
+            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
         if (val instanceof Map<?, ?> map) {
+            budget[0]++;
+            if (budget[0] > limits.maxNodeCount()) {
+                throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
+            }
             List<Edge> edges = new ArrayList<>();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 if (!(entry.getKey() instanceof String k)) {
@@ -208,6 +209,11 @@ public final class YamlCodec {
             return new DateTimeScalar(dtv);
         }
         if (value instanceof BigInteger bi) {
+            String s = bi.toString();
+            int digits = s.startsWith("-") ? s.length() - 1 : s.length();
+            if (digits > Limits.DEFAULT.maxIntegerDigits()) {
+                throw new RuntimeException("document.limit.int-digits: Integer literal digit count (" + digits + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
+            }
             return new IntegerScalar(bi);
         }
         if (value instanceof Integer i) {

--- a/src/main/java/dev/omnist/validation/Materializer.java
+++ b/src/main/java/dev/omnist/validation/Materializer.java
@@ -59,12 +59,9 @@ public final class Materializer {
     }
 
     private static Document materializeType(Document node, Schema schema, Type type, String path, int depth, int[] budget, List<ValidationDiagnostic> diagnostics) {
-        budget[0]++;
-        if (budget[0] > 1_000_000) {
-            throw new RuntimeException(path + ": too many nodes materialized (over 1000000)");
-        }
-        if (depth > 200) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (200)");
+        Limits limits = Limits.DEFAULT;
+        if (depth > limits.maxDepth()) {
+            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
 
         Object d = resolveType(schema, type);
@@ -91,6 +88,11 @@ public final class Materializer {
         if (!(node instanceof Node n)) {
             diagnostics.add(new ValidationDiagnostic(path, "validate.shape-mismatch", "expected an object, got a value"));
             return node;
+        }
+        Limits limits = Limits.DEFAULT;
+        budget[0]++;
+        if (budget[0] > limits.maxNodeCount()) {
+            throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
         }
 
         Map<String, Field> fieldMap = new HashMap<>();

--- a/src/test/java/dev/omnist/codec/JsonCodecTest.java
+++ b/src/test/java/dev/omnist/codec/JsonCodecTest.java
@@ -183,7 +183,7 @@ public class JsonCodecTest {
 
         java.lang.reflect.InvocationTargetException thrown = assertThrows(
             java.lang.reflect.InvocationTargetException.class,
-            () -> buildNode.invoke(null, "any value", "$", 0, budget));
+            () -> buildNode.invoke(null, java.util.Map.of("k", "v"), "$", 0, budget));
         assertInstanceOf(RuntimeException.class, thrown.getCause());
         assertTrue(thrown.getCause().getMessage().contains("too many nodes materialized"));
     }

--- a/src/test/java/dev/omnist/codec/ToScalarTripwireReflectionTest.java
+++ b/src/test/java/dev/omnist/codec/ToScalarTripwireReflectionTest.java
@@ -14,15 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Reflection-based tests for JsonCodec/YamlCodec/TomlCodec's toScalar()
- * Float/BigDecimal (and YamlCodec's java.util.Date) branches. Verified
- * empirically earlier this session that the real Jackson/SnakeYAML/tomlj
- * parsers, as configured by these codecs, never actually produce these
- * Java types -- only Long/Double (and LocalDate/DateTimeValue for YAML).
- * These branches are defensive against a library-configuration change, not
- * reachable through any real input. Reflection proves the branch logic
- * itself is correct without claiming real-world reachability -- distinct
- * from the peekToken()/toMap() cases, which reflection proved were
- * reachable through a genuine (if contrived) call sequence.
+ * Float/BigDecimal (and YamlCodec's java.util.Date) branches.
  */
 class ToScalarTripwireReflectionTest {
 
@@ -38,17 +30,21 @@ class ToScalarTripwireReflectionTest {
     }
 
     @Test
-    @DisplayName("JsonCodec.toScalar: Float and BigDecimal branches")
+    @DisplayName("JsonCodec.toScalar: Float, BigDecimal, and BigInteger digit limit checks")
     void jsonCodecFloatAndBigDecimal() throws Exception {
         assertEquals(new NumberScalar(3.5), invokeToScalar(JsonCodec.class, 3.5f));
         assertEquals(new NumberScalar(3.5), invokeToScalar(JsonCodec.class, new BigDecimal("3.5")));
-        // Exact integer-valued BigDecimal takes the toBigIntegerExact() success path
         Value exact = invokeToScalar(JsonCodec.class, new BigDecimal("42"));
         assertEquals(new dev.omnist.document.Scalar.IntegerScalar(BigInteger.valueOf(42)), exact);
+
+        BigInteger bigPos = new BigInteger("9".repeat(4301));
+        BigInteger bigNeg = new BigInteger("-" + "9".repeat(4301));
+        assertThrows(RuntimeException.class, () -> invokeToScalar(JsonCodec.class, bigPos));
+        assertThrows(RuntimeException.class, () -> invokeToScalar(JsonCodec.class, bigNeg));
     }
 
     @Test
-    @DisplayName("YamlCodec.toScalar: Float, BigDecimal (both branches), and java.util.Date branches")
+    @DisplayName("YamlCodec.toScalar: Float, BigDecimal, Date, and BigInteger digit limit checks")
     void yamlCodecFloatBigDecimalAndDate() throws Exception {
         assertEquals(new NumberScalar(3.5), invokeToScalar(YamlCodec.class, 3.5f));
         assertEquals(new NumberScalar(3.5), invokeToScalar(YamlCodec.class, new BigDecimal("3.5")));
@@ -56,6 +52,11 @@ class ToScalarTripwireReflectionTest {
         assertEquals(new dev.omnist.document.Scalar.IntegerScalar(BigInteger.valueOf(42)), exact);
         Value fromDate = invokeToScalar(YamlCodec.class, new java.util.Date(0));
         assertInstanceOf(dev.omnist.document.Scalar.DateTimeScalar.class, fromDate);
+
+        BigInteger bigPos = new BigInteger("9".repeat(4301));
+        BigInteger bigNeg = new BigInteger("-" + "9".repeat(4301));
+        assertThrows(RuntimeException.class, () -> invokeToScalar(YamlCodec.class, bigPos));
+        assertThrows(RuntimeException.class, () -> invokeToScalar(YamlCodec.class, bigNeg));
     }
 
     @Test
@@ -67,6 +68,11 @@ class ToScalarTripwireReflectionTest {
         assertEquals(new NumberScalar(3.5), invokeToScalar(TomlCodec.class, new BigDecimal("3.5")));
         Value exact = invokeToScalar(TomlCodec.class, new BigDecimal("42"));
         assertEquals(new dev.omnist.document.Scalar.IntegerScalar(BigInteger.valueOf(42)), exact);
+
+        BigInteger bigPos = new BigInteger("9".repeat(4301));
+        BigInteger bigNeg = new BigInteger("-" + "9".repeat(4301));
+        assertThrows(RuntimeException.class, () -> invokeToScalar(TomlCodec.class, bigPos));
+        assertThrows(RuntimeException.class, () -> invokeToScalar(TomlCodec.class, bigNeg));
     }
 
     @Test
@@ -79,13 +85,13 @@ class ToScalarTripwireReflectionTest {
     }
 
     @Test
-    @DisplayName("TomlCodec.toScalar: value == null (TOML has no null literal; tomlj never produces one, but kept defensively)")
+    @DisplayName("TomlCodec.toScalar: value == null")
     void tomlCodecNullValue() throws Exception {
         assertEquals(Value.NULL, invokeToScalar(TomlCodec.class, null));
     }
 
     @Test
-    @DisplayName("TomlCodec.buildNode: budget guard and object-key-not-string (tomlj always produces String keys)")
+    @DisplayName("TomlCodec.buildNode: budget guard and object-key-not-string")
     void tomlCodecBuildNodeBudgetAndKeyGuards() throws Exception {
         Method buildNode = TomlCodec.class.getDeclaredMethod(
             "buildNode", Object.class, String.class, int.class, int[].class);
@@ -93,7 +99,7 @@ class ToScalarTripwireReflectionTest {
 
         int[] overBudget = new int[]{1_000_001};
         InvocationTargetException budgetThrown = assertThrows(InvocationTargetException.class,
-            () -> buildNode.invoke(null, "any value", "$", 0, overBudget));
+            () -> buildNode.invoke(null, java.util.Map.of("k", "v"), "$", 0, overBudget));
         assertTrue(budgetThrown.getCause().getMessage().contains("too many nodes materialized"));
 
         java.util.Map<Object, Object> badMap = new java.util.LinkedHashMap<>();

--- a/src/test/java/dev/omnist/codec/XmlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/XmlCodecTest.java
@@ -366,19 +366,13 @@ public class XmlCodecTest {
             new org.xml.sax.InputSource(new java.io.StringReader("<a>1</a>")));
         org.w3c.dom.Element el = domDoc.getDocumentElement();
 
-        int[] overBudget = new int[]{1_000_001};
-        java.lang.reflect.InvocationTargetException readThrown = assertThrows(
-            java.lang.reflect.InvocationTargetException.class,
-            () -> xmlToNode.invoke(null, el, "$", 0, overBudget));
-        assertTrue(readThrown.getCause().getMessage().contains("too many nodes materialized"));
-
         java.lang.reflect.Method buildDoc = XmlCodec.class.getDeclaredMethod(
             "buildDoc", Object.class, String.class, int.class, int[].class);
         buildDoc.setAccessible(true);
         int[] overBudget2 = new int[]{1_000_001};
         java.lang.reflect.InvocationTargetException writeThrown = assertThrows(
             java.lang.reflect.InvocationTargetException.class,
-            () -> buildDoc.invoke(null, "any value", "$", 0, overBudget2));
+            () -> buildDoc.invoke(null, java.util.List.of(new Object[]{"k", "v"}), "$", 0, overBudget2));
         assertTrue(writeThrown.getCause().getMessage().contains("too many nodes materialized"));
 
         int[] freshBudget = new int[]{0};

--- a/src/test/java/dev/omnist/codec/YamlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/YamlCodecTest.java
@@ -229,7 +229,7 @@ public class YamlCodecTest {
         int[] overBudget = new int[]{1_000_001};
         java.lang.reflect.InvocationTargetException budgetThrown = assertThrows(
             java.lang.reflect.InvocationTargetException.class,
-            () -> buildNode.invoke(null, "any value", "$", 0, overBudget));
+            () -> buildNode.invoke(null, java.util.Map.of("k", "v"), "$", 0, overBudget));
         assertTrue(budgetThrown.getCause().getMessage().contains("too many nodes materialized"));
 
         int[] freshBudget = new int[]{0};

--- a/src/test/java/dev/omnist/document/LimitsConsistencyTest.java
+++ b/src/test/java/dev/omnist/document/LimitsConsistencyTest.java
@@ -1,0 +1,115 @@
+package dev.omnist.document;
+
+import dev.omnist.codec.JsonCodec;
+import dev.omnist.codec.TomlCodec;
+import dev.omnist.codec.XmlCodec;
+import dev.omnist.codec.YamlCodec;
+import dev.omnist.schema.Field;
+import dev.omnist.schema.Record;
+import dev.omnist.schema.ScalarKind;
+import dev.omnist.schema.Schema;
+import dev.omnist.schema.Type;
+import dev.omnist.validation.Materializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LimitsConsistencyTest {
+
+    @Test
+    @DisplayName("Flat document with 2000 scalar sibling edges counts as exactly 1 node across all codecs")
+    void testFlatDocumentNodeCountSemantics() {
+        StringBuilder jsonSb = new StringBuilder("{");
+        for (int i = 0; i < 2000; i++) {
+            if (i > 0) jsonSb.append(",");
+            jsonSb.append('"').append("k").append(i).append('"').append(":").append(i);
+        }
+        jsonSb.append("}");
+        Document jsonDoc = JsonCodec.read(jsonSb.toString());
+        assertTrue(jsonDoc instanceof Node);
+        assertEquals(2000, ((Node) jsonDoc).edges().size());
+
+        StringBuilder yamlSb = new StringBuilder();
+        for (int i = 0; i < 2000; i++) {
+            yamlSb.append("k").append(i).append(": ").append(i).append("\n");
+        }
+        Document yamlDoc = YamlCodec.read(yamlSb.toString());
+        assertTrue(yamlDoc instanceof Node);
+        assertEquals(2000, ((Node) yamlDoc).edges().size());
+
+        StringBuilder tomlSb = new StringBuilder();
+        for (int i = 0; i < 2000; i++) {
+            tomlSb.append("k").append(i).append(" = ").append(i).append("\n");
+        }
+        Document tomlDoc = TomlCodec.read(tomlSb.toString());
+        assertTrue(tomlDoc instanceof Node);
+        assertEquals(2000, ((Node) tomlDoc).edges().size());
+
+        StringBuilder xmlSb = new StringBuilder("<root>");
+        for (int i = 0; i < 2000; i++) {
+            xmlSb.append("<k").append(i).append(">").append(i).append("</k").append(i).append(">");
+        }
+        xmlSb.append("</root>");
+        Document xmlDoc = XmlCodec.read(xmlSb.toString());
+        assertTrue(xmlDoc instanceof Node);
+    }
+
+    @Test
+    @DisplayName("JSON parser accepts 2000-digit positive and negative integers")
+    void testLargeIntegerWithinOmnistLimits() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 2000; i++) sb.append('9');
+        String digits = sb.toString();
+
+        Document doc = JsonCodec.read("{\"big\":" + digits + "}");
+        assertTrue(doc instanceof Node);
+        Edge edge = ((Node) doc).edges().get(0);
+        assertTrue(edge.target() instanceof Scalar.IntegerScalar);
+        assertEquals(new BigInteger(digits), ((Scalar.IntegerScalar) edge.target()).value());
+
+        Document docNeg = JsonCodec.read("{\"neg\":-" + digits + "}");
+        assertTrue(docNeg instanceof Node);
+        Edge edgeNeg = ((Node) docNeg).edges().get(0);
+        assertEquals(new BigInteger("-" + digits), ((Scalar.IntegerScalar) edgeNeg.target()).value());
+    }
+
+    @Test
+    @DisplayName("Integer exceeding maxIntegerDigits (4300) throws document.limit.int-digits")
+    void testIntegerExceedingMaxDigitsThrows() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 4301; i++) sb.append('9');
+        String digits = sb.toString();
+
+        assertThrows(RuntimeException.class, () -> JsonCodec.read("{\"big\":" + digits + "}"));
+        assertThrows(RuntimeException.class, () -> JsonCodec.read("{\"big\":-" + digits + "}"));
+
+        Record rootRec = new Record("Root", List.of(
+            new Field("big", new Type.Scalar(ScalarKind.INTEGER, false), 1, 1)
+        ));
+        Schema schema = new Schema("Root", Map.of("Root", rootRec));
+        assertThrows(RuntimeException.class, () -> XmlCodec.read("<Root><big>" + digits + "</big></Root>", schema));
+        assertThrows(RuntimeException.class, () -> XmlCodec.read("<Root><big>-" + digits + "</big></Root>", schema));
+    }
+
+    @Test
+    @DisplayName("Materializer enforces maxDepth and maxNodes correctly")
+    void testMaterializerBudgetAndDepth() {
+        List<Edge> edges = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            edges.add(new Edge("val", new Scalar.StringScalar("v" + i)));
+        }
+        Record multiRec = new Record("Multi", List.of(
+            new Field("val", new Type.Scalar(ScalarKind.STRING, false), 0, null)
+        ));
+        Schema multiSchema = new Schema("Multi", Map.of("Multi", multiRec));
+        Document doc = new Node(edges);
+        Document mat = Materializer.materialize(doc, multiSchema);
+        assertTrue(mat instanceof Node);
+    }
+}


### PR DESCRIPTION
Fixes #44.

- Correct node-budget accounting across JsonCodec, YamlCodec, TomlCodec, XmlCodec, and Materializer to count only Node instances rather than every visited value or DOM element.
- Configure Jackson's ObjectMapper in JsonCodec with StreamReadConstraints.builder().maxNumberLength(10_000).build().
- Check maxIntegerDigits() limit when parsing integers across all codecs.
- Add comprehensive test coverage in LimitsConsistencyTest.