### PR TITLE
Introduce structured exceptions DocumentParseException and AlgebraException (#50)

### DIFF
--- a/src/main/java/dev/omnist/algebra/AlgebraException.java
+++ b/src/main/java/dev/omnist/algebra/AlgebraException.java
@@ -1,0 +1,57 @@
+package dev.omnist.algebra;
+
+/**
+ * Structured exception thrown when a schema algebra or inference operation fails (omnist-spec ?6).
+ *
+ * <p>Callers that need to surface algebra/inference errors should inspect:
+ * <ul>
+ *   <li>{@link #getPath()} ? target schema element path where the error occurred (e.g. {@code "$"} or {@code "MyRecord.myField"})</li>
+ *   <li>{@link #getCode()} ? machine-readable error code (e.g. {@code algebra.extract-invalidates-root}, {@code algebra.infer-mixed-shape})</li>
+ *   <li>{@link #getMessage()} ? human-readable message explaining the violation</li>
+ * </ul>
+ */
+public class AlgebraException extends IllegalArgumentException {
+    private final String path;
+    private final String code;
+
+    /**
+     * Constructs an algebra exception with path, code, and message.
+     *
+     * @param path    the schema element path where the violation was detected; use {@code "$"} for root-level errors
+     * @param code    the machine-readable error code identifying the error category
+     * @param message human-readable explanation of the error
+     */
+    public AlgebraException(String path, String code, String message) {
+        super(message);
+        this.path = path != null ? path : "$";
+        this.code = code != null ? code : "algebra.error";
+    }
+
+    /**
+     * Constructs an algebra exception with path, code, message, and cause.
+     *
+     * @param path    the schema element path where the violation was detected; use {@code "$"} for root-level errors
+     * @param code    the machine-readable error code identifying the error category
+     * @param message human-readable explanation of the error
+     * @param cause   the underlying exception
+     */
+    public AlgebraException(String path, String code, String message, Throwable cause) {
+        super(message, cause);
+        this.path = path != null ? path : "$";
+        this.code = code != null ? code : "algebra.error";
+    }
+
+    /**
+     * Returns the schema element path where the error was detected.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * Returns the machine-readable error code identifying the violation category.
+     */
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/dev/omnist/algebra/SchemaAlgebra.java
+++ b/src/main/java/dev/omnist/algebra/SchemaAlgebra.java
@@ -251,7 +251,7 @@ public final class SchemaAlgebra {
         }
 
         if (invalidated.contains(schema.root())) {
-            throw new IllegalArgumentException("removing label " + firstBadLabel + " deletes a mandatory field of " + firstBadRecord);
+            throw new AlgebraException(firstBadRecord, "algebra.extract-invalidates-root", "removing label " + firstBadLabel + " deletes a mandatory field of " + firstBadRecord);
         }
 
         Map<String, Record> newEnv = new LinkedHashMap<>();
@@ -420,12 +420,12 @@ public final class SchemaAlgebra {
      */
     public static InferResult inferWithReport(List<Document> samples, String rootName, boolean allowAny) {
         if (samples.isEmpty()) {
-            throw new IllegalArgumentException("cannot infer a schema from zero samples");
+            throw new AlgebraException("$", "algebra.infer-no-samples", "cannot infer a schema from zero samples");
         }
         List<Node> nodes = new ArrayList<>();
         for (Document d : samples) {
             if (!(d instanceof Node n)) {
-                throw new IllegalArgumentException("infer expects object (record) samples at the root");
+                throw new AlgebraException("$", "algebra.infer-scalar-root", "infer expects object (record) samples at the root");
             }
             nodes.add(n);
         }
@@ -442,7 +442,7 @@ public final class SchemaAlgebra {
     private static void inferRecord(List<Node> nodes, String name, Map<String, Record> env,
                                     Set<String> used, boolean allowAny, List<AnyFallback> fallbacks, int depth) {
         if (depth > 100) {
-            throw new IllegalArgumentException("nesting exceeds the maximum depth (100)");
+            throw new AlgebraException(name, "document.limit.depth", "nesting exceeds the maximum depth (100)");
         }
         used.add(name);
 
@@ -526,7 +526,7 @@ public final class SchemaAlgebra {
                 fallbacks.add(new AnyFallback(recordName + "." + label, "mixes objects and values"));
                 return Type.Any.INSTANCE;
             }
-            throw new IllegalArgumentException(recordName + "." + label + ": mixes objects and values; cannot infer one type");
+            throw new AlgebraException(recordName + "." + label, "algebra.infer-mixed-shape", recordName + "." + label + ": mixes objects and values; cannot infer one type");
         }
 
         Set<ScalarKind> kinds = new LinkedHashSet<>();
@@ -562,7 +562,7 @@ public final class SchemaAlgebra {
                 fallbacks.add(new AnyFallback(recordName + "." + label, "values of more than one scalar kind (" + joined + ")"));
                 return Type.Any.INSTANCE;
             }
-            throw new IllegalArgumentException(recordName + "." + label + ": has values of more than one scalar kind (" + joined + ")");
+            throw new AlgebraException(recordName + "." + label, "algebra.infer-conflicting-scalars", recordName + "." + label + ": has values of more than one scalar kind (" + joined + ")");
         }
 
         return new Type.Scalar(kinds.iterator().next(), nullSeen);

--- a/src/main/java/dev/omnist/cli/Cli.java
+++ b/src/main/java/dev/omnist/cli/Cli.java
@@ -324,8 +324,10 @@ public final class Cli {
             writeOutput(opts.outputPath(), writeOsd(extracted, opts.compact()), out);
             return 0;
         } catch (IllegalArgumentException ex) {
+            String path = (ex instanceof dev.omnist.algebra.AlgebraException ae) ? ae.getPath() : "$";
+            String code = (ex instanceof dev.omnist.algebra.AlgebraException ae) ? ae.getCode() : "algebra.extract-invalidates-root";
             if (opts.json()) {
-                out.println(MAPPER.writeValueAsString(new JsonResponse(false, ex.getMessage(), List.of(new JsonError("$", "algebra.extract-invalidates-root", ex.getMessage())))));
+                out.println(MAPPER.writeValueAsString(new JsonResponse(false, ex.getMessage(), List.of(new JsonError(path, code, ex.getMessage())))));
             } else {
                 err.println(ex.getMessage());
             }

--- a/src/main/java/dev/omnist/codec/JsonCodec.java
+++ b/src/main/java/dev/omnist/codec/JsonCodec.java
@@ -77,7 +77,7 @@ public final class JsonCodec {
             throw new IllegalArgumentException("input text cannot be null");
         }
         if (text.length() > MAX_INPUT_LENGTH) {
-            throw new RuntimeException("invalid JSON: input exceeds maximum size limit of " + MAX_INPUT_LENGTH + " characters");
+            throw new DocumentParseException("$", "document.parse-error", "invalid JSON: input exceeds maximum size limit of " + MAX_INPUT_LENGTH + " characters");
         }
         try {
             Object raw = MAPPER.readValue(text, Object.class);
@@ -85,25 +85,25 @@ public final class JsonCodec {
             Document doc = buildNode(raw, "$", 0, budget);
             return doc;
         } catch (IOException e) {
-            throw new RuntimeException("invalid JSON: " + e.getMessage(), e);
+            throw new DocumentParseException("$", "document.parse-error", "invalid JSON: " + e.getMessage(), e);
         }
     }
 
     private static Document buildNode(Object val, String path, int depth, int[] budget) {
         Limits limits = Limits.DEFAULT;
         if (depth > limits.maxDepth()) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
+            throw new DocumentParseException(path, "document.limit.depth", path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
         if (val instanceof Map<?, ?> map) {
             budget[0]++;
             if (budget[0] > limits.maxNodeCount()) {
-                throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
+                throw new DocumentParseException(path, "document.limit.nodes", path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
             }
             List<Edge> edges = new ArrayList<>();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 // Defensive: Invalid JSON (non-string keys) should never occur with ObjectMapper#readValue
                 if (!(entry.getKey() instanceof String k)) {
-                    throw new RuntimeException(path + ": object key " + entry.getKey() + " is not a string");
+                    throw new DocumentParseException(path, "document.unlabeled-element", path + ": object key " + entry.getKey() + " is not a string");
                 }
                 Object v = entry.getValue();
                 String kp = path.equals("$") ? "$." + k : path + "." + k;
@@ -111,7 +111,7 @@ public final class JsonCodec {
                     for (int i = 0; i < list.size(); i++) {
                         Object item = list.get(i);
                         if (item instanceof List<?>) {
-                            throw new RuntimeException(kp + "[" + i + "]: an array of arrays has no labeled-edge form");
+                            throw new DocumentParseException(kp + "[" + i + "]", "document.unlabeled-element", kp + "[" + i + "]: an array of arrays has no labeled-edge form");
                         }
                         Document child = buildNode(item, kp + "[" + i + "]", depth + 2, budget);
                         edges.add(new Edge(k, (Target) child));
@@ -124,7 +124,7 @@ public final class JsonCodec {
             return new Node(edges);
         }
         if (val instanceof List<?>) {
-            throw new RuntimeException(path + ": a bare array has no labeled-edge form (arrays appear only as a repeated field)");
+            throw new DocumentParseException(path, "document.unlabeled-element", path + ": a bare array has no labeled-edge form (arrays appear only as a repeated field)");
         }
         return toScalar(val);
     }
@@ -143,7 +143,7 @@ public final class JsonCodec {
             String s = bi.toString();
             int digits = s.startsWith("-") ? s.length() - 1 : s.length();
             if (digits > Limits.DEFAULT.maxIntegerDigits()) {
-                throw new RuntimeException("document.limit.int-digits: Integer literal digit count (" + digits + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
+                throw new DocumentParseException("$", "document.limit.int-digits", "document.limit.int-digits: Integer literal digit count (" + digits + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
             }
             return new IntegerScalar(bi);
         }

--- a/src/main/java/dev/omnist/codec/TomlCodec.java
+++ b/src/main/java/dev/omnist/codec/TomlCodec.java
@@ -112,7 +112,7 @@ public final class TomlCodec {
                     if (isHex(token) || isOctal(token) || isBinary(token) || isDecimal(token)) {
                         int digitCount = countDigits(token);
                         if (digitCount > 4300) {
-                            throw new RuntimeException("Integer exceeds maximum digit limit of 4300");
+                            throw new DocumentParseException("$", "document.limit.int-digits", "Integer exceeds maximum digit limit of 4300");
                         }
                         if (digitCount > 18) {
                             sb.append("\"__omnist_int__").append(token).append("\"");
@@ -264,7 +264,7 @@ public final class TomlCodec {
             throw new IllegalArgumentException("input text cannot be null");
         }
         if (text.length() > MAX_INPUT_LENGTH) {
-            throw new RuntimeException("invalid TOML: input exceeds maximum size limit of " + MAX_INPUT_LENGTH + " characters");
+            throw new DocumentParseException("$", "document.parse-error", "invalid TOML: input exceeds maximum size limit of " + MAX_INPUT_LENGTH + " characters");
         }
 
         String preprocessed;
@@ -273,7 +273,7 @@ public final class TomlCodec {
             preprocessed = preprocessToml(text);
             result = Toml.parse(preprocessed);
         } catch (Exception | AssertionError e) {
-            throw new RuntimeException("invalid TOML: " + e.getMessage(), e);
+            throw new DocumentParseException("$", "document.parse-error", "invalid TOML: " + e.getMessage(), e);
         }
         return documentFromParseResult(result);
     }
@@ -287,12 +287,12 @@ public final class TomlCodec {
     // through the real Toml.parse() path.
     private static Document documentFromParseResult(TomlParseResult result) {
         if (result.hasErrors()) {
-            throw new RuntimeException("invalid TOML: " + result.errors().get(0).toString());
+            throw new DocumentParseException("$", "document.parse-error", "invalid TOML: " + result.errors().get(0).toString());
         }
 
         Map<String, Object> raw = result.toMap();
         if (raw == null) {
-            throw new RuntimeException("invalid TOML: no document found");
+            throw new DocumentParseException("$", "document.parse-error", "invalid TOML: no document found");
         }
 
         int[] budget = new int[]{0};
@@ -302,7 +302,7 @@ public final class TomlCodec {
     private static Document buildNode(Object val, String path, int depth, int[] budget) {
         Limits limits = Limits.DEFAULT;
         if (depth > limits.maxDepth()) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
+            throw new DocumentParseException(path, "document.limit.depth", path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
         if (val instanceof org.tomlj.TomlTable tt) {
             val = tt.toMap();
@@ -316,12 +316,12 @@ public final class TomlCodec {
         if (val instanceof Map<?, ?> map) {
             budget[0]++;
             if (budget[0] > limits.maxNodeCount()) {
-                throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
+                throw new DocumentParseException(path, "document.limit.nodes", path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
             }
             List<Edge> edges = new ArrayList<>();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 if (!(entry.getKey() instanceof String k)) {
-                    throw new RuntimeException(path + ": object key " + entry.getKey() + " is not a string");
+                    throw new DocumentParseException(path, "document.unlabeled-element", path + ": object key " + entry.getKey() + " is not a string");
                 }
                 Object v = entry.getValue();
                 if (v instanceof org.tomlj.TomlArray ta) {
@@ -338,7 +338,7 @@ public final class TomlCodec {
                             item = ta2.toList();
                         }
                         if (item instanceof List<?>) {
-                            throw new RuntimeException(kp + "[" + i + "]: an array of arrays has no labeled-edge form");
+                            throw new DocumentParseException(kp + "[" + i + "]", "document.unlabeled-element", kp + "[" + i + "]: an array of arrays has no labeled-edge form");
                         }
                         Document child = buildNode(item, kp + "[" + i + "]", depth + 2, budget);
                         edges.add(new Edge(k, (Target) child));
@@ -407,7 +407,7 @@ public final class TomlCodec {
             String s = bi.toString();
             int digits = s.startsWith("-") ? s.length() - 1 : s.length();
             if (digits > Limits.DEFAULT.maxIntegerDigits()) {
-                throw new RuntimeException("document.limit.int-digits: Integer literal digit count (" + digits + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
+                throw new DocumentParseException("$", "document.limit.int-digits", "document.limit.int-digits: Integer literal digit count (" + digits + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
             }
             return new IntegerScalar(bi);
         }

--- a/src/main/java/dev/omnist/codec/XmlCodec.java
+++ b/src/main/java/dev/omnist/codec/XmlCodec.java
@@ -83,7 +83,7 @@ public final class XmlCodec {
             throw new IllegalArgumentException("input text cannot be null");
         }
         if (text.length() > MAX_INPUT_LENGTH) {
-            throw new RuntimeException("invalid XML: input exceeds maximum size limit of " + MAX_INPUT_LENGTH + " characters");
+            throw new DocumentParseException("$", "document.parse-error", "invalid XML: input exceeds maximum size limit of " + MAX_INPUT_LENGTH + " characters");
         }
 
         org.w3c.dom.Element rootElem;
@@ -104,7 +104,7 @@ public final class XmlCodec {
             org.w3c.dom.Document domDoc = dbf.newDocumentBuilder().parse(is);
             rootElem = requireRootElement(domDoc);
         } catch (Exception e) {
-            throw new RuntimeException("invalid XML: " + e.getMessage(), e);
+            throw new DocumentParseException("$", "document.parse-error", "invalid XML: " + e.getMessage(), e);
         }
 
         int[] budget = new int[]{0};
@@ -139,7 +139,7 @@ public final class XmlCodec {
     private static org.w3c.dom.Element requireRootElement(org.w3c.dom.Document domDoc) {
         org.w3c.dom.Element rootElem = domDoc.getDocumentElement();
         if (rootElem == null) {
-            throw new RuntimeException("no document element found");
+            throw new DocumentParseException("$", "document.parse-error", "no document element found");
         }
         return rootElem;
     }
@@ -147,7 +147,7 @@ public final class XmlCodec {
     private static Object xmlToNode(org.w3c.dom.Element elem, String path, int depth, int[] budget) {
         Limits limits = Limits.DEFAULT;
         if (depth > limits.maxDepth()) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
+            throw new DocumentParseException(path, "document.limit.depth", path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
 
         List<org.w3c.dom.Element> childElements = new ArrayList<>();
@@ -176,7 +176,7 @@ public final class XmlCodec {
                     // never null) character data -- kept as defensive handling for the
                     // nullable-Object-returning Node.getNodeValue() signature itself.
                     if (text != null && !text.trim().isEmpty()) {
-                        throw new RuntimeException(path + ": mixed content (text alongside child elements) is outside the data-XML profile");
+                        throw new DocumentParseException(path, "document.unlabeled-element", path + ": mixed content (text alongside child elements) is outside the data-XML profile");
                     }
                 }
             }
@@ -225,7 +225,7 @@ public final class XmlCodec {
                     if (XML_INT_RE.matcher(s).matches()) {
                         String clean = s.startsWith("-") ? s.substring(1) : s;
                         if (clean.length() > Limits.DEFAULT.maxIntegerDigits()) {
-                            throw new RuntimeException("document.limit.int-digits: Integer literal digit count (" + clean.length() + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
+                            throw new DocumentParseException("$", "document.limit.int-digits", "document.limit.int-digits: Integer literal digit count (" + clean.length() + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
                         }
                         return new BigInteger(s);
                     }
@@ -274,7 +274,7 @@ public final class XmlCodec {
         if (val instanceof List<?> list) {
             budget[0]++;
             if (budget[0] > limits.maxNodeCount()) {
-                throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
+                throw new DocumentParseException(path, "document.limit.nodes", path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
             }
             List<Edge> edges = new ArrayList<>();
             for (Object item : list) {

--- a/src/main/java/dev/omnist/codec/YamlCodec.java
+++ b/src/main/java/dev/omnist/codec/YamlCodec.java
@@ -130,7 +130,7 @@ public final class YamlCodec {
             throw new IllegalArgumentException("input text cannot be null");
         }
         if (text.length() > MAX_INPUT_LENGTH) {
-            throw new RuntimeException("invalid YAML: input exceeds maximum size limit of " + MAX_INPUT_LENGTH + " characters");
+            throw new DocumentParseException("$", "document.parse-error", "invalid YAML: input exceeds maximum size limit of " + MAX_INPUT_LENGTH + " characters");
         }
 
         LoaderOptions loaderOptions = new LoaderOptions();
@@ -139,14 +139,21 @@ public final class YamlCodec {
         DumperOptions dumperOptions = new DumperOptions();
         Yaml yaml = new Yaml(constructor, new Representer(dumperOptions), dumperOptions, loaderOptions, resolver);
 
-        Iterable<Object> docs = yaml.loadAll(text);
-        Iterator<Object> it = docs.iterator();
-        if (!it.hasNext()) {
-            throw new RuntimeException("no document found");
-        }
-        Object raw = it.next();
-        if (it.hasNext()) {
-            throw new RuntimeException("expected a single document in the stream but found another document");
+        Object raw;
+        try {
+            Iterable<Object> docs = yaml.loadAll(text);
+            Iterator<Object> it = docs.iterator();
+            if (!it.hasNext()) {
+                throw new DocumentParseException("$", "document.parse-error", "no document found");
+            }
+            raw = it.next();
+            if (it.hasNext()) {
+                throw new DocumentParseException("$", "document.parse-error", "expected a single document in the stream but found another document");
+            }
+        } catch (DocumentParseException dpe) {
+            throw dpe;
+        } catch (Exception e) {
+            throw new DocumentParseException("$", "document.parse-error", "invalid YAML: " + e.getMessage(), e);
         }
 
         int[] budget = new int[]{0};
@@ -156,17 +163,17 @@ public final class YamlCodec {
     private static Document buildNode(Object val, String path, int depth, int[] budget) {
         Limits limits = Limits.DEFAULT;
         if (depth > limits.maxDepth()) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
+            throw new DocumentParseException(path, "document.limit.depth", path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
         if (val instanceof Map<?, ?> map) {
             budget[0]++;
             if (budget[0] > limits.maxNodeCount()) {
-                throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
+                throw new DocumentParseException(path, "document.limit.nodes", path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
             }
             List<Edge> edges = new ArrayList<>();
             for (Map.Entry<?, ?> entry : map.entrySet()) {
                 if (!(entry.getKey() instanceof String k)) {
-                    throw new RuntimeException(path + ": object key " + entry.getKey() + " is not a string (unlabeled element in key position)");
+                    throw new DocumentParseException(path, "document.unlabeled-element", path + ": object key " + entry.getKey() + " is not a string (unlabeled element in key position)");
                 }
                 Object v = entry.getValue();
                 String kp = path.equals("$") ? "$." + k : path + "." + k;
@@ -174,7 +181,7 @@ public final class YamlCodec {
                     for (int i = 0; i < list.size(); i++) {
                         Object item = list.get(i);
                         if (item instanceof List<?>) {
-                            throw new RuntimeException(kp + "[" + i + "]: an array of arrays has no labeled-edge form");
+                            throw new DocumentParseException(kp + "[" + i + "]", "document.unlabeled-element", kp + "[" + i + "]: an array of arrays has no labeled-edge form");
                         }
                         Document child = buildNode(item, kp + "[" + i + "]", depth + 2, budget);
                         edges.add(new Edge(k, (Target) child));
@@ -187,7 +194,7 @@ public final class YamlCodec {
             return new dev.omnist.document.Node(edges);
         }
         if (val instanceof List<?>) {
-            throw new RuntimeException(path + ": a bare array has no labeled-edge form (arrays appear only as a repeated field)");
+            throw new DocumentParseException(path, "document.unlabeled-element", path + ": a bare array has no labeled-edge form (arrays appear only as a repeated field)");
         }
         return toScalar(val);
     }
@@ -212,7 +219,7 @@ public final class YamlCodec {
             String s = bi.toString();
             int digits = s.startsWith("-") ? s.length() - 1 : s.length();
             if (digits > Limits.DEFAULT.maxIntegerDigits()) {
-                throw new RuntimeException("document.limit.int-digits: Integer literal digit count (" + digits + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
+                throw new DocumentParseException("$", "document.limit.int-digits", "document.limit.int-digits: Integer literal digit count (" + digits + ") exceeds maximum limit of " + Limits.DEFAULT.maxIntegerDigits());
             }
             return new IntegerScalar(bi);
         }

--- a/src/main/java/dev/omnist/conformance/Track1Runner.java
+++ b/src/main/java/dev/omnist/conformance/Track1Runner.java
@@ -580,6 +580,12 @@ public final class Track1Runner {
     }
 
     private static List<JsonDiagnostic> extractParserDiagnostics(Throwable ex) {
+        if (ex instanceof dev.omnist.document.DocumentParseException dpe) {
+            return List.of(new JsonDiagnostic(dpe.getPath(), dpe.getCode()));
+        }
+        if (ex instanceof dev.omnist.algebra.AlgebraException ae) {
+            return List.of(new JsonDiagnostic(ae.getPath(), ae.getCode()));
+        }
         if (ex instanceof OmlParseException ope) {
             return List.of(new JsonDiagnostic(ope.getPath(), ope.getCode()));
         }

--- a/src/main/java/dev/omnist/conformance/Track2Runner.java
+++ b/src/main/java/dev/omnist/conformance/Track2Runner.java
@@ -777,6 +777,12 @@ public final class Track2Runner {
     }
 
     private static List<JsonDiagnostic> extractParserDiagnostics(Throwable ex) {
+        if (ex instanceof dev.omnist.document.DocumentParseException dpe) {
+            return List.of(new JsonDiagnostic(dpe.getPath(), dpe.getCode()));
+        }
+        if (ex instanceof dev.omnist.algebra.AlgebraException ae) {
+            return List.of(new JsonDiagnostic(ae.getPath(), ae.getCode()));
+        }
         if (ex instanceof OmlParseException ope) {
             return List.of(new JsonDiagnostic(ope.getPath(), ope.getCode()));
         }

--- a/src/main/java/dev/omnist/document/DocumentParseException.java
+++ b/src/main/java/dev/omnist/document/DocumentParseException.java
@@ -1,0 +1,58 @@
+package dev.omnist.document;
+
+/**
+ * Structured exception thrown when a document fails to parse, violates safety limits,
+ * or contains invalid/unsupported structures across format codecs (omnist-spec ?7, ?8).
+ *
+ * <p>Callers that need to surface document parse errors should inspect:
+ * <ul>
+ *   <li>{@link #getPath()} ? JSONPath-style document path where the error was detected (e.g. {@code "$"} or {@code "$.a[0].b"})</li>
+ *   <li>{@link #getCode()} ? machine-readable error code (e.g. {@code document.limit.depth}, {@code document.unlabeled-element})</li>
+ *   <li>{@link #getMessage()} ? human-readable message explaining the violation</li>
+ * </ul>
+ */
+public class DocumentParseException extends RuntimeException {
+    private final String path;
+    private final String code;
+
+    /**
+     * Constructs a document parse exception with path, code, and message.
+     *
+     * @param path    the document path where the violation was detected; use {@code "$"} for root-level errors
+     * @param code    the machine-readable error code identifying the error category
+     * @param message human-readable explanation of the error
+     */
+    public DocumentParseException(String path, String code, String message) {
+        super(message);
+        this.path = path != null ? path : "$";
+        this.code = code != null ? code : "document.parse-error";
+    }
+
+    /**
+     * Constructs a document parse exception with path, code, message, and cause.
+     *
+     * @param path    the document path where the violation was detected; use {@code "$"} for root-level errors
+     * @param code    the machine-readable error code identifying the error category
+     * @param message human-readable explanation of the error
+     * @param cause   the underlying exception
+     */
+    public DocumentParseException(String path, String code, String message, Throwable cause) {
+        super(message, cause);
+        this.path = path != null ? path : "$";
+        this.code = code != null ? code : "document.parse-error";
+    }
+
+    /**
+     * Returns the JSONPath-style document path where the error was detected.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * Returns the machine-readable error code identifying the violation category.
+     */
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/dev/omnist/validation/Materializer.java
+++ b/src/main/java/dev/omnist/validation/Materializer.java
@@ -61,7 +61,7 @@ public final class Materializer {
     private static Document materializeType(Document node, Schema schema, Type type, String path, int depth, int[] budget, List<ValidationDiagnostic> diagnostics) {
         Limits limits = Limits.DEFAULT;
         if (depth > limits.maxDepth()) {
-            throw new RuntimeException(path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
+            throw new DocumentParseException(path, "document.limit.depth", path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
         }
 
         Object d = resolveType(schema, type);
@@ -92,7 +92,7 @@ public final class Materializer {
         Limits limits = Limits.DEFAULT;
         budget[0]++;
         if (budget[0] > limits.maxNodeCount()) {
-            throw new RuntimeException(path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
+            throw new DocumentParseException(path, "document.limit.nodes", path + ": too many nodes materialized (over " + limits.maxNodeCount() + ")");
         }
 
         Map<String, Field> fieldMap = new HashMap<>();

--- a/src/test/java/dev/omnist/document/StructuredExceptionTest.java
+++ b/src/test/java/dev/omnist/document/StructuredExceptionTest.java
@@ -1,0 +1,155 @@
+package dev.omnist.document;
+
+import dev.omnist.algebra.AlgebraException;
+import dev.omnist.algebra.SchemaAlgebra;
+import dev.omnist.codec.JsonCodec;
+import dev.omnist.codec.TomlCodec;
+import dev.omnist.codec.XmlCodec;
+import dev.omnist.codec.YamlCodec;
+import dev.omnist.schema.Field;
+import dev.omnist.schema.Record;
+import dev.omnist.schema.ScalarKind;
+import dev.omnist.schema.Schema;
+import dev.omnist.schema.Type;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StructuredExceptionTest {
+
+    @Test
+    @DisplayName("DocumentParseException properties and constructors")
+    void testDocumentParseExceptionProperties() {
+        DocumentParseException ex1 = new DocumentParseException("$.foo", "document.limit.depth", "depth error");
+        assertEquals("$.foo", ex1.getPath());
+        assertEquals("document.limit.depth", ex1.getCode());
+        assertEquals("depth error", ex1.getMessage());
+
+        DocumentParseException ex1b = new DocumentParseException(null, null, "null path and code");
+        assertEquals("$", ex1b.getPath());
+        assertEquals("document.parse-error", ex1b.getCode());
+
+        Throwable cause = new RuntimeException("cause");
+        DocumentParseException ex2 = new DocumentParseException(null, null, "error with cause", cause);
+        assertEquals("$", ex2.getPath());
+        assertEquals("document.parse-error", ex2.getCode());
+        assertSame(cause, ex2.getCause());
+
+        DocumentParseException ex2b = new DocumentParseException("$.bar", "document.limit.nodes", "nodes with cause", cause);
+        assertEquals("$.bar", ex2b.getPath());
+        assertEquals("document.limit.nodes", ex2b.getCode());
+        assertSame(cause, ex2b.getCause());
+    }
+
+    @Test
+    @DisplayName("AlgebraException properties and constructors")
+    void testAlgebraExceptionProperties() {
+        AlgebraException ex1 = new AlgebraException("MyRecord.field", "algebra.infer-mixed-shape", "mixed shape");
+        assertEquals("MyRecord.field", ex1.getPath());
+        assertEquals("algebra.infer-mixed-shape", ex1.getCode());
+        assertEquals("mixed shape", ex1.getMessage());
+
+        AlgebraException ex1b = new AlgebraException(null, null, "null path and code");
+        assertEquals("$", ex1b.getPath());
+        assertEquals("algebra.error", ex1b.getCode());
+
+        Throwable cause = new RuntimeException("cause");
+        AlgebraException ex2 = new AlgebraException(null, null, "error with cause", cause);
+        assertEquals("$", ex2.getPath());
+        assertEquals("algebra.error", ex2.getCode());
+        assertSame(cause, ex2.getCause());
+
+        AlgebraException ex2b = new AlgebraException("MyRecord", "algebra.extract-invalidates-root", "extract with cause", cause);
+        assertEquals("MyRecord", ex2b.getPath());
+        assertEquals("algebra.extract-invalidates-root", ex2b.getCode());
+        assertSame(cause, ex2b.getCause());
+    }
+
+    @Test
+    @DisplayName("JsonCodec throws DocumentParseException with correct codes and paths")
+    void testJsonCodecStructuredExceptions() {
+        DocumentParseException exArray = assertThrows(DocumentParseException.class, () -> JsonCodec.read("[1, 2]"));
+        assertEquals("document.unlabeled-element", exArray.getCode());
+        assertEquals("$", exArray.getPath());
+
+        DocumentParseException exNested = assertThrows(DocumentParseException.class, () -> JsonCodec.read("{\"a\": [[1]]}"));
+        assertEquals("document.unlabeled-element", exNested.getCode());
+        assertEquals("$.a[0]", exNested.getPath());
+
+        DocumentParseException exParse = assertThrows(DocumentParseException.class, () -> JsonCodec.read("{invalid json"));
+        assertEquals("document.parse-error", exParse.getCode());
+    }
+
+    @Test
+    @DisplayName("YamlCodec throws DocumentParseException with correct codes and paths")
+    void testYamlCodecStructuredExceptions() {
+        DocumentParseException exArray = assertThrows(DocumentParseException.class, () -> YamlCodec.read("- 1\n- 2\n"));
+        assertEquals("document.unlabeled-element", exArray.getCode());
+        assertEquals("$", exArray.getPath());
+
+        DocumentParseException exNested = assertThrows(DocumentParseException.class, () -> YamlCodec.read("a:\n  - [1, 2]\n"));
+        assertEquals("document.unlabeled-element", exNested.getCode());
+        assertEquals("$.a[0]", exNested.getPath());
+
+        DocumentParseException exParse = assertThrows(DocumentParseException.class, () -> YamlCodec.read("a: [1, 2"));
+        assertEquals("document.parse-error", exParse.getCode());
+    }
+
+    @Test
+    @DisplayName("TomlCodec throws DocumentParseException with correct codes and paths")
+    void testTomlCodecStructuredExceptions() {
+        DocumentParseException exNested = assertThrows(DocumentParseException.class, () -> TomlCodec.read("a = [[1]]\n"));
+        assertEquals("document.unlabeled-element", exNested.getCode());
+        assertEquals("$.a[0]", exNested.getPath());
+
+        DocumentParseException exParse = assertThrows(DocumentParseException.class, () -> TomlCodec.read("a = \n"));
+        assertEquals("document.parse-error", exParse.getCode());
+    }
+
+    @Test
+    @DisplayName("XmlCodec throws DocumentParseException with correct codes and paths")
+    void testXmlCodecStructuredExceptions() {
+        DocumentParseException exParse = assertThrows(DocumentParseException.class, () -> XmlCodec.read("<root><unclosed>"));
+        assertEquals("document.parse-error", exParse.getCode());
+
+        DocumentParseException exMixed = assertThrows(DocumentParseException.class, () -> XmlCodec.read("<root>text<child>1</child></root>"));
+        assertEquals("document.unlabeled-element", exMixed.getCode());
+    }
+
+    @Test
+    @DisplayName("SchemaAlgebra throws AlgebraException with correct codes and paths")
+    void testSchemaAlgebraStructuredExceptions() {
+        // Zero samples
+        AlgebraException exZero = assertThrows(AlgebraException.class, () -> SchemaAlgebra.infer(List.of()));
+        assertEquals("algebra.infer-no-samples", exZero.getCode());
+        assertEquals("$", exZero.getPath());
+
+        // Scalar root
+        AlgebraException exScalar = assertThrows(AlgebraException.class, () -> SchemaAlgebra.infer(List.of(new Scalar.IntegerScalar(java.math.BigInteger.ONE))));
+        assertEquals("algebra.infer-scalar-root", exScalar.getCode());
+        assertEquals("$", exScalar.getPath());
+
+        // Mixed shape
+        Document d1 = new Node(List.of(new Edge("a", new Scalar.IntegerScalar(java.math.BigInteger.ONE))));
+        Document d2 = new Node(List.of(new Edge("a", new Node(List.of(new Edge("b", new Scalar.StringScalar("s")))))));
+        AlgebraException exMixed = assertThrows(AlgebraException.class, () -> SchemaAlgebra.infer(List.of(d1, d2)));
+        assertEquals("algebra.infer-mixed-shape", exMixed.getCode());
+
+        // Conflicting scalars
+        Document d3 = new Node(List.of(new Edge("a", new Scalar.IntegerScalar(java.math.BigInteger.ONE))));
+        Document d4 = new Node(List.of(new Edge("a", new Scalar.StringScalar("s"))));
+        AlgebraException exConf = assertThrows(AlgebraException.class, () -> SchemaAlgebra.infer(List.of(d3, d4)));
+        assertEquals("algebra.infer-conflicting-scalars", exConf.getCode());
+
+        // Extract invalidates root
+        Record rec = new Record("Root", List.of(new Field("req", new Type.Scalar(ScalarKind.STRING, false), 1, 1)));
+        Schema schema = new Schema("Root", Map.of("Root", rec));
+        AlgebraException exExt = assertThrows(AlgebraException.class, () -> SchemaAlgebra.extract(schema, Set.of("opt")));
+        assertEquals("algebra.extract-invalidates-root", exExt.getCode());
+    }
+}


### PR DESCRIPTION
Fixes #50.

- Added DocumentParseException and AlgebraException carrying structured code and path properties.
- Converted JsonCodec, YamlCodec, TomlCodec, XmlCodec, Materializer, and SchemaAlgebra throw sites to use structured exceptions.
- Updated Track1Runner, Track2Runner, and Cli to directly consume structured exception properties.
- Added comprehensive unit tests in StructuredExceptionTest.