### PR TITLE
Centralize temporal parsing and edge grouping in shared utilities (#49)

### DIFF
--- a/src/main/java/dev/omnist/codec/JsonCodec.java
+++ b/src/main/java/dev/omnist/codec/JsonCodec.java
@@ -211,7 +211,7 @@ public final class JsonCodec {
             throw new WriteException(rep.toString(), rep);
         }
         Object prepared = prepareJson(node, "$", 0, strict);
-        Object grouped = grouped(prepared, 0);
+        Object grouped = dev.omnist.document.PathUtils.groupEdges(prepared);
         try {
             if (indent != null && indent > 0) {
                 return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(grouped);
@@ -306,31 +306,4 @@ public final class JsonCodec {
         }
     }
 
-    private static Object grouped(Object node, int depth) {
-        // No depth guard here: grouped()'s tree mirrors prepareJson's output,
-        // which mirrors the original document already bounded by check().
-        if (!(node instanceof List<?> list)) {
-            return node;
-        }
-        Map<String, Integer> counts = new HashMap<>();
-        for (Object item : list) {
-            Object[] edge = (Object[]) item;
-            String label = (String) edge[0];
-            counts.put(label, counts.getOrDefault(label, 0) + 1);
-        }
-        Map<String, Object> out = new LinkedHashMap<>();
-        for (Object item : list) {
-            Object[] edge = (Object[]) item;
-            String label = (String) edge[0];
-            Object child = grouped(edge[1], depth + 1);
-            if (counts.get(label) > 1) {
-                @SuppressWarnings("unchecked")
-                List<Object> targetList = (List<Object>) out.computeIfAbsent(label, k -> new ArrayList<>());
-                targetList.add(child);
-            } else {
-                out.put(label, child);
-            }
-        }
-        return out;
-    }
 }

--- a/src/main/java/dev/omnist/codec/TomlCodec.java
+++ b/src/main/java/dev/omnist/codec/TomlCodec.java
@@ -471,7 +471,7 @@ public final class TomlCodec {
         Document stripped = stripNulls(node, "$", rep, 0);
         Object prepared = prepareToml(stripped, "$", 0, strict);
         @SuppressWarnings("unchecked")
-        Map<String, Object> grouped = (Map<String, Object>) grouped(prepared, 0);
+        Map<String, Object> grouped = (Map<String, Object>) dev.omnist.document.PathUtils.groupEdges(prepared);
 
         StringBuilder sb = new StringBuilder();
         writeTable("", grouped, sb);
@@ -675,31 +675,4 @@ public final class TomlCodec {
         }
     }
 
-    private static Object grouped(Object node, int depth) {
-        // No depth guard here: grouped()'s tree mirrors prepareToml's output,
-        // which mirrors the stripped document already bounded by stripNulls.
-        if (!(node instanceof List<?> list)) {
-            return node;
-        }
-        Map<String, Integer> counts = new HashMap<>();
-        for (Object item : list) {
-            Object[] edge = (Object[]) item;
-            String label = (String) edge[0];
-            counts.put(label, counts.getOrDefault(label, 0) + 1);
-        }
-        Map<String, Object> out = new LinkedHashMap<>();
-        for (Object item : list) {
-            Object[] edge = (Object[]) item;
-            String label = (String) edge[0];
-            Object child = grouped(edge[1], depth + 1);
-            if (counts.get(label) > 1) {
-                @SuppressWarnings("unchecked")
-                List<Object> targetList = (List<Object>) out.computeIfAbsent(label, k -> new ArrayList<>());
-                targetList.add(child);
-            } else {
-                out.put(label, child);
-            }
-        }
-        return out;
-    }
 }

--- a/src/main/java/dev/omnist/codec/YamlCodec.java
+++ b/src/main/java/dev/omnist/codec/YamlCodec.java
@@ -80,18 +80,7 @@ public final class YamlCodec {
     }
 
     private static DateTimeValue parseDateTimeValue(String text) {
-        text = text.replace(' ', 'T');
-        if (text.endsWith("Z") || text.endsWith("z")) {
-            LocalDateTime dt = LocalDateTime.parse(text.substring(0, text.length() - 1));
-            return DateTimeValue.of(dt, ZoneOffset.UTC);
-        }
-        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
-        if (signPos > 10) {
-            LocalDateTime dt = LocalDateTime.parse(text.substring(0, signPos));
-            ZoneOffset offset = ZoneOffset.of(text.substring(signPos));
-            return DateTimeValue.of(dt, offset);
-        }
-        return DateTimeValue.of(LocalDateTime.parse(text));
+        return DateTimeValue.parse(text.replace(' ', 'T'));
     }
 
     /** Maximum accepted input length in characters, guarding against oversized YAML input. */

--- a/src/main/java/dev/omnist/codec/YamlCodec.java
+++ b/src/main/java/dev/omnist/codec/YamlCodec.java
@@ -282,7 +282,7 @@ public final class YamlCodec {
             throw new WriteException(rep.toString(), rep);
         }
         Object prepared = prepareYaml(node, "$", 0, strict);
-        Object grouped = grouped(prepared, 0);
+        Object grouped = dev.omnist.document.PathUtils.groupEdges(prepared);
 
         DumperOptions dumperOptions = new DumperOptions();
         dumperOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
@@ -370,34 +370,6 @@ public final class YamlCodec {
             TimeScalar time = (TimeScalar) doc;
             return time.value().format();
         }
-    }
-
-    private static Object grouped(Object node, int depth) {
-        // No depth guard here: grouped()'s tree mirrors prepareYaml's output,
-        // which mirrors the original document already bounded by check().
-        if (!(node instanceof List<?> list)) {
-            return node;
-        }
-        Map<String, Integer> counts = new HashMap<>();
-        for (Object item : list) {
-            Object[] edge = (Object[]) item;
-            String label = (String) edge[0];
-            counts.put(label, counts.getOrDefault(label, 0) + 1);
-        }
-        Map<String, Object> out = new LinkedHashMap<>();
-        for (Object item : list) {
-            Object[] edge = (Object[]) item;
-            String label = (String) edge[0];
-            Object child = grouped(edge[1], depth + 1);
-            if (counts.get(label) > 1) {
-                @SuppressWarnings("unchecked")
-                List<Object> targetList = (List<Object>) out.computeIfAbsent(label, k -> new ArrayList<>());
-                targetList.add(child);
-            } else {
-                out.put(label, child);
-            }
-        }
-        return out;
     }
 
     private static class CustomRepresenter extends Representer {

--- a/src/main/java/dev/omnist/conformance/Track1Runner.java
+++ b/src/main/java/dev/omnist/conformance/Track1Runner.java
@@ -710,52 +710,32 @@ public final class Track1Runner {
     }
 
     private static DateTimeValue parseDateTimeValue(String text) {
-        if (text.endsWith("Z") || text.endsWith("z")) {
-            java.time.LocalDateTime dt = java.time.LocalDateTime.parse(text.substring(0, text.length() - 1));
-            return DateTimeValue.of(dt, ZoneOffset.UTC);
-        }
-        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
-        if (signPos > 10) {
-            java.time.LocalDateTime dt = java.time.LocalDateTime.parse(text.substring(0, signPos));
-            ZoneOffset offset = ZoneOffset.of(text.substring(signPos));
-            return DateTimeValue.of(dt, offset);
-        }
-        return DateTimeValue.of(java.time.LocalDateTime.parse(text));
+        return dev.omnist.document.DateTimeValue.parse(text);
     }
 
-    private static TimeValue parseTimeValue(String text) {
-        if (text.endsWith("Z") || text.endsWith("z")) {
-            java.time.LocalTime t = java.time.LocalTime.parse(text.substring(0, text.length() - 1));
-            return TimeValue.of(t, ZoneOffset.UTC);
-        }
-        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
-        if (signPos > 0 && text.indexOf(':') < signPos) {
-            java.time.LocalTime t = java.time.LocalTime.parse(text.substring(0, signPos));
-            ZoneOffset offset = ZoneOffset.of(text.substring(signPos));
-            return TimeValue.of(t, offset);
-        }
-        return TimeValue.of(java.time.LocalTime.parse(text));
+    private static dev.omnist.document.TimeValue parseTimeValue(String text) {
+        return dev.omnist.document.TimeValue.parse(text);
     }
 
-    private static boolean isEquivalentDoc(Document a, Document b) {
+    private static boolean isEquivalentDoc(dev.omnist.document.Document a, dev.omnist.document.Document b) {
         if (a.equals(b)) return true;
         if (a instanceof dev.omnist.document.Node na && b instanceof dev.omnist.document.Node nb) {
             if (na.edges().size() != nb.edges().size()) return false;
-            Map<String, List<Target>> mapA = new HashMap<>();
-            for (Edge e : na.edges()) {
-                mapA.computeIfAbsent(e.label(), k -> new ArrayList<>()).add(e.target());
+            java.util.Map<String, java.util.List<dev.omnist.document.Target>> mapA = new java.util.HashMap<>();
+            for (dev.omnist.document.Edge e : na.edges()) {
+                mapA.computeIfAbsent(e.label(), k -> new java.util.ArrayList<>()).add(e.target());
             }
-            Map<String, List<Target>> mapB = new HashMap<>();
-            for (Edge e : nb.edges()) {
-                mapB.computeIfAbsent(e.label(), k -> new ArrayList<>()).add(e.target());
+            java.util.Map<String, java.util.List<dev.omnist.document.Target>> mapB = new java.util.HashMap<>();
+            for (dev.omnist.document.Edge e : nb.edges()) {
+                mapB.computeIfAbsent(e.label(), k -> new java.util.ArrayList<>()).add(e.target());
             }
             if (!mapA.keySet().equals(mapB.keySet())) return false;
             for (String k : mapA.keySet()) {
-                List<Target> listA = mapA.get(k);
-                List<Target> listB = mapB.get(k);
+                java.util.List<dev.omnist.document.Target> listA = mapA.get(k);
+                java.util.List<dev.omnist.document.Target> listB = mapB.get(k);
                 if (listA.size() != listB.size()) return false;
                 for (int i = 0; i < listA.size(); i++) {
-                    if (!isEquivalentDoc((Document) listA.get(i), (Document) listB.get(i))) {
+                    if (!isEquivalentDoc((dev.omnist.document.Document) listA.get(i), (dev.omnist.document.Document) listB.get(i))) {
                         return false;
                     }
                 }
@@ -764,4 +744,5 @@ public final class Track1Runner {
         }
         return false;
     }
+
 }

--- a/src/main/java/dev/omnist/conformance/Track2Runner.java
+++ b/src/main/java/dev/omnist/conformance/Track2Runner.java
@@ -907,52 +907,32 @@ public final class Track2Runner {
     }
 
     private static DateTimeValue parseDateTimeValue(String text) {
-        if (text.endsWith("Z") || text.endsWith("z")) {
-            java.time.LocalDateTime dt = java.time.LocalDateTime.parse(text.substring(0, text.length() - 1));
-            return DateTimeValue.of(dt, ZoneOffset.UTC);
-        }
-        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
-        if (signPos > 10) {
-            java.time.LocalDateTime dt = java.time.LocalDateTime.parse(text.substring(0, signPos));
-            ZoneOffset offset = ZoneOffset.of(text.substring(signPos));
-            return DateTimeValue.of(dt, offset);
-        }
-        return DateTimeValue.of(java.time.LocalDateTime.parse(text));
+        return dev.omnist.document.DateTimeValue.parse(text);
     }
 
-    private static TimeValue parseTimeValue(String text) {
-        if (text.endsWith("Z") || text.endsWith("z")) {
-            java.time.LocalTime t = java.time.LocalTime.parse(text.substring(0, text.length() - 1));
-            return TimeValue.of(t, ZoneOffset.UTC);
-        }
-        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
-        if (signPos > 0 && text.indexOf(':') < signPos) {
-            java.time.LocalTime t = java.time.LocalTime.parse(text.substring(0, signPos));
-            ZoneOffset offset = ZoneOffset.of(text.substring(signPos));
-            return TimeValue.of(t, offset);
-        }
-        return TimeValue.of(java.time.LocalTime.parse(text));
+    private static dev.omnist.document.TimeValue parseTimeValue(String text) {
+        return dev.omnist.document.TimeValue.parse(text);
     }
 
-    private static boolean isEquivalentDoc(Document a, Document b) {
+    private static boolean isEquivalentDoc(dev.omnist.document.Document a, dev.omnist.document.Document b) {
         if (a.equals(b)) return true;
         if (a instanceof dev.omnist.document.Node na && b instanceof dev.omnist.document.Node nb) {
             if (na.edges().size() != nb.edges().size()) return false;
-            Map<String, List<Target>> mapA = new HashMap<>();
-            for (Edge e : na.edges()) {
-                mapA.computeIfAbsent(e.label(), k -> new ArrayList<>()).add(e.target());
+            java.util.Map<String, java.util.List<dev.omnist.document.Target>> mapA = new java.util.HashMap<>();
+            for (dev.omnist.document.Edge e : na.edges()) {
+                mapA.computeIfAbsent(e.label(), k -> new java.util.ArrayList<>()).add(e.target());
             }
-            Map<String, List<Target>> mapB = new HashMap<>();
-            for (Edge e : nb.edges()) {
-                mapB.computeIfAbsent(e.label(), k -> new ArrayList<>()).add(e.target());
+            java.util.Map<String, java.util.List<dev.omnist.document.Target>> mapB = new java.util.HashMap<>();
+            for (dev.omnist.document.Edge e : nb.edges()) {
+                mapB.computeIfAbsent(e.label(), k -> new java.util.ArrayList<>()).add(e.target());
             }
             if (!mapA.keySet().equals(mapB.keySet())) return false;
             for (String k : mapA.keySet()) {
-                List<Target> listA = mapA.get(k);
-                List<Target> listB = mapB.get(k);
+                java.util.List<dev.omnist.document.Target> listA = mapA.get(k);
+                java.util.List<dev.omnist.document.Target> listB = mapB.get(k);
                 if (listA.size() != listB.size()) return false;
                 for (int i = 0; i < listA.size(); i++) {
-                    if (!isEquivalentDoc((Document) listA.get(i), (Document) listB.get(i))) {
+                    if (!isEquivalentDoc((dev.omnist.document.Document) listA.get(i), (dev.omnist.document.Document) listB.get(i))) {
                         return false;
                     }
                 }
@@ -961,4 +941,5 @@ public final class Track2Runner {
         }
         return false;
     }
+
 }

--- a/src/main/java/dev/omnist/document/DateTimeValue.java
+++ b/src/main/java/dev/omnist/document/DateTimeValue.java
@@ -59,4 +59,27 @@ public record DateTimeValue(LocalDateTime dateTime, ZoneOffset offset) {
         return sb.toString();
     }
 
+    /**
+     * Parses an ISO-8601 date-time string into a {@link DateTimeValue}.
+     * Supports un-offset local date-times (e.g. {@code "2024-01-01T12:00:00"}), UTC 'Z' (e.g. {@code "2024-01-01T12:00:00Z"}),
+     * and numeric offsets (e.g. {@code "2024-01-01T12:00:00+02:00"}).
+     *
+     * @param text the ISO-8601 date-time string to parse; must not be {@code null}
+     * @return the parsed {@link DateTimeValue}
+     */
+    public static DateTimeValue parse(String text) {
+        Objects.requireNonNull(text, "text must not be null");
+        if (text.endsWith("Z") || text.endsWith("z")) {
+            LocalDateTime dt = LocalDateTime.parse(text.substring(0, text.length() - 1));
+            return DateTimeValue.of(dt, ZoneOffset.UTC);
+        }
+        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
+        if (signPos > 10) {
+            LocalDateTime dt = LocalDateTime.parse(text.substring(0, signPos));
+            ZoneOffset offset = ZoneOffset.of(text.substring(signPos));
+            return DateTimeValue.of(dt, offset);
+        }
+        return DateTimeValue.of(LocalDateTime.parse(text));
+    }
+
 }

--- a/src/main/java/dev/omnist/document/PathUtils.java
+++ b/src/main/java/dev/omnist/document/PathUtils.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Shared utilities for constructing canonical document paths in diagnostics and report adjustments (omnist-spec ?8).
+ * Shared utilities for constructing canonical document paths in diagnostics and report adjustments (omnist-spec §8).
  */
 public final class PathUtils {
 
@@ -43,5 +43,42 @@ public final class PathUtils {
             return base + "[" + index + "]";
         }
         return base;
+    }
+
+    /**
+     * Groups repeated child edges into lists or single values for JSON, YAML, and TOML serialization.
+     * Preserves the first-seen insertion order of edge labels.
+     *
+     * @param node the prepared tree node or scalar value
+     * @return the grouped data structure (Maps/Lists/Scalars)
+     */
+    public static Object groupEdges(Object node) {
+        return groupEdges(node, 0);
+    }
+
+    private static Object groupEdges(Object node, int depth) {
+        if (!(node instanceof java.util.List<?> list)) {
+            return node;
+        }
+        java.util.Map<String, Integer> counts = new java.util.HashMap<>();
+        for (Object item : list) {
+            Object[] edge = (Object[]) item;
+            String label = (String) edge[0];
+            counts.put(label, counts.getOrDefault(label, 0) + 1);
+        }
+        java.util.Map<String, Object> out = new java.util.LinkedHashMap<>();
+        for (Object item : list) {
+            Object[] edge = (Object[]) item;
+            String label = (String) edge[0];
+            Object child = groupEdges(edge[1], depth + 1);
+            if (counts.get(label) > 1) {
+                @SuppressWarnings("unchecked")
+                java.util.List<Object> targetList = (java.util.List<Object>) out.computeIfAbsent(label, k -> new java.util.ArrayList<>());
+                targetList.add(child);
+            } else {
+                out.put(label, child);
+            }
+        }
+        return out;
     }
 }

--- a/src/main/java/dev/omnist/document/TimeValue.java
+++ b/src/main/java/dev/omnist/document/TimeValue.java
@@ -58,4 +58,27 @@ public record TimeValue(LocalTime time, ZoneOffset offset) {
         }
         return sb.toString();
     }
+    /**
+     * Parses an ISO-8601 time string into a {@link TimeValue}.
+     * Supports un-offset local times (e.g. {@code "12:00:00"}), UTC 'Z' (e.g. {@code "12:00:00Z"}),
+     * and numeric offsets (e.g. {@code "12:00:00+02:00"}).
+     *
+     * @param text the ISO-8601 time string to parse; must not be {@code null}
+     * @return the parsed {@link TimeValue}
+     */
+    public static TimeValue parse(String text) {
+        Objects.requireNonNull(text, "text must not be null");
+        if (text.endsWith("Z") || text.endsWith("z")) {
+            LocalTime t = LocalTime.parse(text.substring(0, text.length() - 1));
+            return TimeValue.of(t, ZoneOffset.UTC);
+        }
+        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
+        if (signPos > 0 && text.indexOf(':') < signPos) {
+            LocalTime t = LocalTime.parse(text.substring(0, signPos));
+            ZoneOffset offset = ZoneOffset.of(text.substring(signPos));
+            return TimeValue.of(t, offset);
+        }
+        return TimeValue.of(LocalTime.parse(text));
+    }
+
 }

--- a/src/main/java/dev/omnist/oml/OmlLexer.java
+++ b/src/main/java/dev/omnist/oml/OmlLexer.java
@@ -433,36 +433,11 @@ public class OmlLexer {
     }
 
     private DateTimeValue parseDateTimeValue(String text) {
-        if (text.endsWith("Z")) {
-            LocalDateTime dt = LocalDateTime.parse(text.substring(0, text.length() - 1));
-            return DateTimeValue.of(dt, ZoneOffset.UTC);
-        }
-        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
-        if (signPos > 10) {
-            LocalDateTime dt = LocalDateTime.parse(text.substring(0, signPos));
-            ZoneOffset offset = ZoneOffset.of(text.substring(signPos));
-            return DateTimeValue.of(dt, offset);
-        }
-        return DateTimeValue.of(LocalDateTime.parse(text));
+        return DateTimeValue.parse(text);
     }
 
     private TimeValue parseTimeValue(String text) {
-        if (text.endsWith("Z")) {
-            LocalTime t = LocalTime.parse(text.substring(0, text.length() - 1));
-            return TimeValue.of(t, ZoneOffset.UTC);
-        }
-        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
-        // text.indexOf(':') < signPos is always true whenever signPos > 0: this
-        // method is only ever called with text TIME_PATTERN already matched, whose
-        // mandatory "HH:MM" prefix puts the first ':' at index 2, while a +/-HH:MM
-        // offset suffix (the only place a sign char can appear) can't start before
-        // index 5 -- so the ':' is provably always earlier than any real signPos.
-        if (signPos > 0 && text.indexOf(':') < signPos) {
-            LocalTime t = LocalTime.parse(text.substring(0, signPos));
-            ZoneOffset offset = ZoneOffset.of(text.substring(signPos));
-            return TimeValue.of(t, offset);
-        }
-        return TimeValue.of(LocalTime.parse(text));
+        return TimeValue.parse(text);
     }
 
     private char consumeChar() {

--- a/src/main/java/dev/omnist/validation/Materializer.java
+++ b/src/main/java/dev/omnist/validation/Materializer.java
@@ -216,35 +216,10 @@ public final class Materializer {
     }
 
     private static TimeValue parseTimeValue(String text) {
-        if (text.endsWith("Z")) {
-            java.time.LocalTime t = java.time.LocalTime.parse(text.substring(0, text.length() - 1));
-            return TimeValue.of(t, java.time.ZoneOffset.UTC);
-        }
-        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
-        // text.indexOf(':') < signPos is always true whenever signPos > 0: this
-        // method is only ever called with text ANCHORED_TIME already matched,
-        // whose mandatory "HH:MM" prefix puts the first ':' at index 2, while a
-        // +/-HH:MM offset suffix can't start before index 5 -- same reasoning as
-        // OmlLexer.parseTimeValue's twin check.
-        if (signPos > 0 && text.indexOf(':') < signPos) {
-            java.time.LocalTime t = java.time.LocalTime.parse(text.substring(0, signPos));
-            java.time.ZoneOffset offset = java.time.ZoneOffset.of(text.substring(signPos));
-            return TimeValue.of(t, offset);
-        }
-        return TimeValue.of(java.time.LocalTime.parse(text));
+        return TimeValue.parse(text);
     }
 
     private static DateTimeValue parseDateTimeValue(String text) {
-        if (text.endsWith("Z")) {
-            java.time.LocalDateTime dt = java.time.LocalDateTime.parse(text.substring(0, text.length() - 1));
-            return DateTimeValue.of(dt, java.time.ZoneOffset.UTC);
-        }
-        int signPos = Math.max(text.lastIndexOf('+'), text.lastIndexOf('-'));
-        if (signPos > 10) {
-            java.time.LocalDateTime dt = java.time.LocalDateTime.parse(text.substring(0, signPos));
-            java.time.ZoneOffset offset = java.time.ZoneOffset.of(text.substring(signPos));
-            return DateTimeValue.of(dt, offset);
-        }
-        return DateTimeValue.of(java.time.LocalDateTime.parse(text));
+        return DateTimeValue.parse(text);
     }
 }

--- a/src/test/java/dev/omnist/document/SharedTraversalAndTemporalTest.java
+++ b/src/test/java/dev/omnist/document/SharedTraversalAndTemporalTest.java
@@ -1,0 +1,112 @@
+package dev.omnist.document;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SharedTraversalAndTemporalTest {
+
+    @Test
+    @DisplayName("DateTimeValue.parse correctly parses un-offset, UTC, and offset date-times")
+    void testDateTimeValueParse() {
+        assertThrows(NullPointerException.class, () -> DateTimeValue.parse(null));
+
+        DateTimeValue unOffset = DateTimeValue.parse("2024-01-01T12:30:45");
+        assertEquals(LocalDateTime.of(2024, 1, 1, 12, 30, 45), unOffset.dateTime());
+        assertNull(unOffset.offset());
+
+        DateTimeValue utcZ = DateTimeValue.parse("2024-01-01T12:30:45Z");
+        assertEquals(LocalDateTime.of(2024, 1, 1, 12, 30, 45), utcZ.dateTime());
+        assertEquals(ZoneOffset.UTC, utcZ.offset());
+
+        DateTimeValue utcLowerZ = DateTimeValue.parse("2024-01-01T12:30:45z");
+        assertEquals(LocalDateTime.of(2024, 1, 1, 12, 30, 45), utcLowerZ.dateTime());
+        assertEquals(ZoneOffset.UTC, utcLowerZ.offset());
+
+        DateTimeValue offsetPlus = DateTimeValue.parse("2024-01-01T12:30:45+05:30");
+        assertEquals(LocalDateTime.of(2024, 1, 1, 12, 30, 45), offsetPlus.dateTime());
+        assertEquals(ZoneOffset.of("+05:30"), offsetPlus.offset());
+
+        DateTimeValue offsetMinus = DateTimeValue.parse("2024-01-01T12:30:45-08:00");
+        assertEquals(LocalDateTime.of(2024, 1, 1, 12, 30, 45), offsetMinus.dateTime());
+        assertEquals(ZoneOffset.of("-08:00"), offsetMinus.offset());
+    }
+
+    @Test
+    @DisplayName("TimeValue.parse correctly parses un-offset, UTC, and offset times")
+    void testTimeValueParse() {
+        assertThrows(NullPointerException.class, () -> TimeValue.parse(null));
+
+        TimeValue unOffset = TimeValue.parse("12:30:45");
+        assertEquals(LocalTime.of(12, 30, 45), unOffset.time());
+        assertNull(unOffset.offset());
+
+        TimeValue utcZ = TimeValue.parse("12:30:45Z");
+        assertEquals(LocalTime.of(12, 30, 45), utcZ.time());
+        assertEquals(ZoneOffset.UTC, utcZ.offset());
+
+        TimeValue utcLowerZ = TimeValue.parse("12:30:45z");
+        assertEquals(LocalTime.of(12, 30, 45), utcLowerZ.time());
+        assertEquals(ZoneOffset.UTC, utcLowerZ.offset());
+
+        TimeValue offsetPlus = TimeValue.parse("12:30:45+05:30");
+        assertEquals(LocalTime.of(12, 30, 45), offsetPlus.time());
+        assertEquals(ZoneOffset.of("+05:30"), offsetPlus.offset());
+
+        
+        // Time with leading sign where colon is after sign
+        assertThrows(Exception.class, () -> TimeValue.parse("+12:00"));
+
+        TimeValue offsetMinus = TimeValue.parse("12:30:45-08:00");
+        assertEquals(LocalTime.of(12, 30, 45), offsetMinus.time());
+        assertEquals(ZoneOffset.of("-08:00"), offsetMinus.offset());
+    }
+
+    @Test
+    @DisplayName("PathUtils.groupEdges groups repeated and single edges correctly")
+    void testGroupEdges() {
+        // Scalar passthrough
+        assertEquals("scalar", PathUtils.groupEdges("scalar"));
+
+        // Single edge
+        List<Object> singleEdge = Collections.singletonList((Object) new Object[]{"key", "value"});
+        Object resSingle = PathUtils.groupEdges(singleEdge);
+        assertTrue(resSingle instanceof Map);
+        Map<?, ?> mapSingle = (Map<?, ?>) resSingle;
+        assertEquals("value", mapSingle.get("key"));
+
+        // Repeated edges
+        List<Object> repeatedEdges = List.of(
+            (Object) new Object[]{"items", "v1"},
+            (Object) new Object[]{"items", "v2"},
+            (Object) new Object[]{"other", "v3"}
+        );
+        Object resRep = PathUtils.groupEdges(repeatedEdges);
+        assertTrue(resRep instanceof Map);
+        Map<?, ?> mapRep = (Map<?, ?>) resRep;
+        assertEquals(List.of("v1", "v2"), mapRep.get("items"));
+        assertEquals("v3", mapRep.get("other"));
+
+        // Nested structure
+        List<Object> nestedEdges = Collections.singletonList(
+            (Object) new Object[]{"parent", List.of(
+                (Object) new Object[]{"child", "val1"},
+                (Object) new Object[]{"child", "val2"}
+            )}
+        );
+        Object resNested = PathUtils.groupEdges(nestedEdges);
+        assertTrue(resNested instanceof Map);
+        Map<?, ?> mapNested = (Map<?, ?>) resNested;
+        assertTrue(mapNested.get("parent") instanceof Map);
+        Map<?, ?> childMap = (Map<?, ?>) mapNested.get("parent");
+        assertEquals(List.of("val1", "val2"), childMap.get("child"));
+    }
+}


### PR DESCRIPTION
Fixes #49.

- Centralized ISO-8601 parsing into `DateTimeValue.parse` and `TimeValue.parse`, eliminating 4 duplicate implementations across `OmlLexer`, `Materializer`, `Track1Runner`, and `Track2Runner`.
- Centralized edge grouping into `PathUtils.groupEdges`, eliminating duplicate `grouped` methods across `JsonCodec`, `YamlCodec`, and `TomlCodec`.
- Added unit tests in `SharedTraversalAndTemporalTest`.