### PR TITLE
Support configurable indent widths in JsonCodec.write (#52)

### DIFF
--- a/src/main/java/dev/omnist/codec/JsonCodec.java
+++ b/src/main/java/dev/omnist/codec/JsonCodec.java
@@ -214,7 +214,11 @@ public final class JsonCodec {
         Object grouped = dev.omnist.document.PathUtils.groupEdges(prepared);
         try {
             if (indent != null && indent > 0) {
-                return MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(grouped);
+                com.fasterxml.jackson.core.util.DefaultPrettyPrinter printer = new com.fasterxml.jackson.core.util.DefaultPrettyPrinter();
+                com.fasterxml.jackson.core.util.DefaultIndenter indenter = new com.fasterxml.jackson.core.util.DefaultIndenter(" ".repeat(indent), com.fasterxml.jackson.core.util.DefaultIndenter.SYS_LF);
+                printer.indentObjectsWith(indenter);
+                printer.indentArraysWith(indenter);
+                return MAPPER.writer(printer).writeValueAsString(grouped);
             } else {
                 return MAPPER.writeValueAsString(grouped);
             }

--- a/src/test/java/dev/omnist/codec/JsonCodecTest.java
+++ b/src/test/java/dev/omnist/codec/JsonCodecTest.java
@@ -141,11 +141,16 @@ public class JsonCodecTest {
     }
 
     @Test
-    @DisplayName("write: indent produces pretty-printed output")
+    @DisplayName("write: indent produces pretty-printed output with requested indent width")
     void testWriteWithIndent() {
         Document doc = new Node(List.of(new Edge("a", new IntegerScalar(BigInteger.ONE))));
-        String pretty = JsonCodec.write(doc, 2, false, null);
-        assertTrue(pretty.contains("\n"));
+        String pretty2 = JsonCodec.write(doc, 2, false, null);
+        assertTrue(pretty2.contains("\n"));
+        assertTrue(pretty2.contains("  \"a\""));
+
+        String pretty4 = JsonCodec.write(doc, 4, false, null);
+        assertTrue(pretty4.contains("\n"));
+        assertTrue(pretty4.contains("    \"a\""));
     }
 
     @Test


### PR DESCRIPTION
Fixes #52.

- Implemented configurable integer indent widths using Jackson's `DefaultPrettyPrinter` and `DefaultIndenter` instead of hardcoding default formatting.
- Preserved existing API contract for Integer indent parameter (null or <=0 for compact, >0 for custom space count).
- Added unit tests in JsonCodecTest verifying 2-space and 4-space indentation.