### PR TITLE
Make read(text) primary and deprecate read(text, schema) in JSON, YAML, TOML codecs (#51)

### DIFF
--- a/src/main/java/dev/omnist/codec/JsonCodec.java
+++ b/src/main/java/dev/omnist/codec/JsonCodec.java
@@ -43,36 +43,14 @@ public final class JsonCodec {
     private JsonCodec() {}
 
     /**
-     * Parses JSON text into a {@link Document} without schema guidance.
-     * Equivalent to {@code read(text, null)}.
-     *
-     * @param text the JSON text; must not be {@code null}
-     * @return the parsed document
-     * @throws RuntimeException if the JSON is syntactically invalid or structurally unsupported
-     */
-    public static Document read(String text) {
-        return read(text, null);
-    }
-
-    /**
      * Parses JSON text into a {@link Document}.
      *
-     * <p>The {@code schema} parameter is intentionally unused here: JSON's own
-     * grammar already distinguishes strings/numbers/booleans natively, so there is
-     * no scalar-kind ambiguity for a schema to resolve at parse time (unlike
-     * {@link XmlCodec#read(String, dev.omnist.schema.Schema)}, where every value
-     * is a string until schema-guided pre-typing runs). Schema-driven coercion of
-     * an already-typed value (e.g. a JSON string into a schema's {@code date}
-     * field) is a separate concern handled by a later
-     * {@link dev.omnist.validation.Materializer} call, not by this method.
-     *
-     * @param text   the JSON text; must not be {@code null}
-     * @param schema accepted for call-site symmetry with the other format codecs; has no effect
+     * @param text the JSON text; must not be {@code null}
      * @return the parsed document
      * @throws RuntimeException if the JSON is syntactically invalid, or if the root value is an array,
      *         or if nesting depth exceeds 200, or if node count exceeds 1,000,000
      */
-    public static Document read(String text, Schema schema) {
+    public static Document read(String text) {
         if (text == null) {
             throw new IllegalArgumentException("input text cannot be null");
         }
@@ -87,6 +65,16 @@ public final class JsonCodec {
         } catch (IOException e) {
             throw new DocumentParseException("$", "document.parse-error", "invalid JSON: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * @deprecated The {@code schema} parameter is ignored for JSON. Use {@link #read(String)}
+     *             followed by {@link dev.omnist.validation.Materializer#materialize(Document, Schema)}
+     *             if schema-driven coercion is required.
+     */
+    @Deprecated(since = "0.1.0", forRemoval = true)
+    public static Document read(String text, Schema schema) {
+        return read(text);
     }
 
     private static Document buildNode(Object val, String path, int depth, int[] budget) {

--- a/src/main/java/dev/omnist/codec/TomlCodec.java
+++ b/src/main/java/dev/omnist/codec/TomlCodec.java
@@ -232,34 +232,13 @@ public final class TomlCodec {
     public static final int MAX_INPUT_LENGTH = 2_000_000;
 
     /**
-     * Parses TOML text into a {@link Document} without schema guidance.
-     * Equivalent to {@code read(text, null)}.
+     * Parses TOML text into a {@link Document}.
      *
      * @param text the TOML text; must not be {@code null}
      * @return the parsed document
      * @throws RuntimeException if the TOML is syntactically invalid or exceeds {@link #MAX_INPUT_LENGTH}
      */
     public static Document read(String text) {
-        return read(text, null);
-    }
-
-    /**
-     * Parses TOML text into a {@link Document}.
-     *
-     * <p>The {@code schema} parameter is intentionally unused here: TOML's own
-     * grammar already distinguishes strings/integers/numbers/booleans/temporal
-     * values natively, so there is no scalar-kind ambiguity for a schema to
-     * resolve (unlike {@link XmlCodec#read(String, dev.omnist.schema.Schema)},
-     * where every value is a string until schema-guided pre-typing runs). The
-     * parameter exists only so callers can invoke every format codec through the
-     * same two-argument shape without special-casing TOML.
-     *
-     * @param text   the TOML text; must not be {@code null}
-     * @param schema accepted for call-site symmetry with the other format codecs; has no effect
-     * @return the parsed document
-     * @throws RuntimeException if the TOML is syntactically invalid or exceeds {@link #MAX_INPUT_LENGTH}
-     */
-    public static Document read(String text, Schema schema) {
         if (text == null) {
             throw new IllegalArgumentException("input text cannot be null");
         }
@@ -276,6 +255,16 @@ public final class TomlCodec {
             throw new DocumentParseException("$", "document.parse-error", "invalid TOML: " + e.getMessage(), e);
         }
         return documentFromParseResult(result);
+    }
+
+    /**
+     * @deprecated The {@code schema} parameter is ignored for TOML. Use {@link #read(String)}
+     *             followed by {@link dev.omnist.validation.Materializer#materialize(Document, Schema)}
+     *             if schema-driven coercion is required.
+     */
+    @Deprecated(since = "0.1.0", forRemoval = true)
+    public static Document read(String text, Schema schema) {
+        return read(text);
     }
 
     // Extracted so the toMap()==null defensive branch can be exercised via

--- a/src/main/java/dev/omnist/codec/YamlCodec.java
+++ b/src/main/java/dev/omnist/codec/YamlCodec.java
@@ -87,34 +87,13 @@ public final class YamlCodec {
     public static final int MAX_INPUT_LENGTH = 2_000_000;
 
     /**
-     * Parses YAML text into a {@link Document} without schema guidance.
-     * Equivalent to {@code read(text, null)}.
+     * Parses YAML text into a {@link Document}.
      *
      * @param text the YAML text; must not be {@code null}
      * @return the parsed document
      * @throws RuntimeException if the YAML is syntactically invalid or exceeds {@link #MAX_INPUT_LENGTH}
      */
     public static Document read(String text) {
-        return read(text, null);
-    }
-
-    /**
-     * Parses YAML text into a {@link Document}.
-     *
-     * <p>The {@code schema} parameter is intentionally unused here: YAML's own
-     * grammar already distinguishes strings/integers/numbers/booleans/temporal
-     * values natively (via its resolvers), so there is no scalar-kind ambiguity
-     * for a schema to resolve (unlike {@link XmlCodec#read(String, dev.omnist.schema.Schema)},
-     * where every value is a string until schema-guided pre-typing runs). The
-     * parameter exists only so callers can invoke every format codec through the
-     * same two-argument shape without special-casing YAML.
-     *
-     * @param text   the YAML text; must not be {@code null}
-     * @param schema accepted for call-site symmetry with the other format codecs; has no effect
-     * @return the parsed document
-     * @throws RuntimeException if the YAML is syntactically invalid or exceeds {@link #MAX_INPUT_LENGTH}
-     */
-    public static Document read(String text, Schema schema) {
         if (text == null) {
             throw new IllegalArgumentException("input text cannot be null");
         }
@@ -147,6 +126,16 @@ public final class YamlCodec {
 
         int[] budget = new int[]{0};
         return buildNode(raw, "$", 0, budget);
+    }
+
+    /**
+     * @deprecated The {@code schema} parameter is ignored for YAML. Use {@link #read(String)}
+     *             followed by {@link dev.omnist.validation.Materializer#materialize(Document, Schema)}
+     *             if schema-driven coercion is required.
+     */
+    @Deprecated(since = "0.1.0", forRemoval = true)
+    public static Document read(String text, Schema schema) {
+        return read(text);
     }
 
     private static Document buildNode(Object val, String path, int depth, int[] budget) {

--- a/src/test/java/dev/omnist/codec/TomlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/TomlCodecTest.java
@@ -372,4 +372,13 @@ public class TomlCodecTest {
         Document delReadBack = TomlCodec.read(delWritten);
         assertEquals(delDoc, delReadBack);
     }
+
+    @Test
+    @DisplayName("read: deprecated read(text, schema) overload delegates to read(text)")
+    @SuppressWarnings("deprecation")
+    void testDeprecatedReadWithSchema() {
+        Document doc = TomlCodec.read("a = 1\n", null);
+        assertNotNull(doc);
+    }
+
 }


### PR DESCRIPTION
Fixes #51.

- Made `read(String text)` the primary parse method in `JsonCodec`, `YamlCodec`, and `TomlCodec`.
- Deprecated `read(String text, Schema schema)` across JSON, YAML, and TOML codecs with Javadoc guidance directing callers to `Materializer.materialize` if schema-driven coercion is desired.
- Left `XmlCodec.read(String text, Schema schema)` unchanged per omnist-spec#44 (schema-guided pretyping).