### PR TITLE
Enforce strict CLI option parsing and gate stack traces behind --debug/-v (#53)

### DIFF
--- a/docs/02-cli-reference.md
+++ b/docs/02-cli-reference.md
@@ -20,6 +20,16 @@ omnist <command> [subcommand] [options]
 
 ---
 
+
+---
+
+## Global Options
+
+- `--compact`: write output in compact single-line form where supported.
+- `-o <file>`: write output to a file instead of standard output.
+- `--debug`, `-v`: enable verbose debug error output including JVM stack traces.
+- `--json`: format errors and boolean results as machine-readable JSON.
+
 ## Commands & Subcommands
 
 ### 1. `format`

--- a/src/main/java/dev/omnist/cli/Cli.java
+++ b/src/main/java/dev/omnist/cli/Cli.java
@@ -62,7 +62,8 @@ public final class Cli {
         boolean json,
         boolean allowAny,
         String outputPath,
-        String severity
+        String severity,
+        boolean debug
     ) {}
 
     /**
@@ -77,6 +78,7 @@ public final class Cli {
      *         check" outcome (e.g. {@code validate} on a non-conforming document)
      */
     public static int run(String[] args, PrintStream out, PrintStream err, InputStream in) {
+        boolean debug = false;
         try {
             List<String> positionals = new ArrayList<>();
             boolean compact = false;
@@ -94,40 +96,57 @@ public final class Cli {
                 String arg = args[i];
                 if (arg.equals("--compact")) {
                     compact = true;
+                } else if (arg.equals("--debug") || arg.equals("-v")) {
+                    debug = true;
                 } else if (arg.equals("-o")) {
-                    if (i + 1 < args.length) {
-                        outputPath = args[++i];
+                    if (i + 1 >= args.length) {
+                        err.println("Missing value for option: " + arg);
+                        return 2;
                     }
+                    outputPath = args[++i];
                 } else if (arg.equals("--from")) {
-                    if (i + 1 < args.length) {
-                        fromFormat = args[++i];
+                    if (i + 1 >= args.length) {
+                        err.println("Missing value for option: " + arg);
+                        return 2;
                     }
+                    fromFormat = args[++i];
                 } else if (arg.equals("--to")) {
-                    if (i + 1 < args.length) {
-                        toFormat = args[++i];
+                    if (i + 1 >= args.length) {
+                        err.println("Missing value for option: " + arg);
+                        return 2;
                     }
+                    toFormat = args[++i];
                 } else if (arg.equals("--schema")) {
-                    if (i + 1 < args.length) {
-                        schemaPath = args[++i];
+                    if (i + 1 >= args.length) {
+                        err.println("Missing value for option: " + arg);
+                        return 2;
                     }
+                    schemaPath = args[++i];
                 } else if (arg.equals("--keep")) {
-                    if (i + 1 < args.length) {
-                        keepLabels = args[++i];
+                    if (i + 1 >= args.length) {
+                        err.println("Missing value for option: " + arg);
+                        return 2;
                     }
+                    keepLabels = args[++i];
                 } else if (arg.equals("--result-format")) {
-                    if (i + 1 < args.length) {
-                        resultFormat = args[++i];
+                    if (i + 1 >= args.length) {
+                        err.println("Missing value for option: " + arg);
+                        return 2;
                     }
+                    resultFormat = args[++i];
                 } else if (arg.equals("--json")) {
                     json = true;
                 } else if (arg.equals("--allow-any")) {
                     allowAny = true;
                 } else if (arg.equals("--severity")) {
-                    if (i + 1 < args.length) {
-                        severity = args[++i];
+                    if (i + 1 >= args.length) {
+                        err.println("Missing value for option: " + arg);
+                        return 2;
                     }
+                    severity = args[++i];
                 } else if (arg.startsWith("-") && !arg.equals("-")) {
-                    // Ignore or skip unrecognized options
+                    err.println("Unrecognized option: " + arg);
+                    return 2;
                 } else {
                     positionals.add(arg);
                 }
@@ -139,7 +158,7 @@ public final class Cli {
             }
 
             Options opts = new Options(compact, fromFormat, toFormat, schemaPath, keepLabels,
-                resultFormat, json, allowAny, outputPath, severity);
+                resultFormat, json, allowAny, outputPath, severity, debug);
             String cmd = positionals.get(0);
 
             return switch (cmd) {
@@ -156,7 +175,9 @@ public final class Cli {
 
         } catch (Exception ex) {
             err.println("Error: " + ex.getMessage());
-            ex.printStackTrace(err);
+            if (debug) {
+                ex.printStackTrace(err);
+            }
             return 2;
         }
     }

--- a/src/test/java/dev/omnist/cli/CliCoverageTest.java
+++ b/src/test/java/dev/omnist/cli/CliCoverageTest.java
@@ -60,7 +60,7 @@ class CliCoverageTest {
     void testUnknownCommandAndOptions() {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
-        int code = execute(new String[]{"foobar", "--unknown-flag"}, null, out, err);
+        int code = execute(new String[]{"foobar"}, null, out, err);
         assertEquals(2, code);
         assertTrue(err.toString(StandardCharsets.UTF_8).contains("Unknown command: foobar"));
     }
@@ -325,7 +325,8 @@ class CliCoverageTest {
         for (String flag : new String[]{"-o", "--from", "--to", "--schema", "--keep", "--result-format", "--severity"}) {
             out.reset(); err.reset();
             int code = execute(new String[]{"format", "-", flag}, "a: 1\n", out, err);
-            assertEquals(0, code, "flag " + flag + " at end should be ignored, not crash");
+            assertEquals(2, code, "flag " + flag + " at end without value should be rejected");
+            assertTrue(err.toString(StandardCharsets.UTF_8).contains("Missing value for option: " + flag));
         }
     }
 
@@ -481,4 +482,82 @@ class CliCoverageTest {
         assertEquals("document.parse-error", Cli.getInferErrorCode(null));
         assertEquals("document.parse-error", Cli.getInferErrorCode("some unrelated message"));
     }
+
+    @Test
+    void testUnrecognizedOption() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int code = execute(new String[]{"format", "-", "--unknown-flag"}, "", out, err);
+        assertEquals(2, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("Unrecognized option: --unknown-flag"));
+    }
+
+    @Test
+    void testMissingOptionValue() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int code = execute(new String[]{"format", "-", "--to"}, "", out, err);
+        assertEquals(2, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("Missing value for option: --to"));
+
+        err.reset();
+        code = execute(new String[]{"format", "-", "-o"}, "", out, err);
+        assertEquals(2, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("Missing value for option: -o"));
+
+        err.reset();
+        code = execute(new String[]{"format", "-", "--from"}, "", out, err);
+        assertEquals(2, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("Missing value for option: --from"));
+
+        err.reset();
+        code = execute(new String[]{"validate", "-", "--schema"}, "", out, err);
+        assertEquals(2, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("Missing value for option: --schema"));
+
+        err.reset();
+        code = execute(new String[]{"schema", "extract", "-", "--keep"}, "", out, err);
+        assertEquals(2, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("Missing value for option: --keep"));
+
+        err.reset();
+        code = execute(new String[]{"schema", "is-empty", "-", "--result-format"}, "", out, err);
+        assertEquals(2, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("Missing value for option: --result-format"));
+
+        err.reset();
+        code = execute(new String[]{"schema", "lint", "-", "--severity"}, "", out, err);
+        assertEquals(2, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("Missing value for option: --severity"));
+    }
+
+    @Test
+    void testDebugFlagGateStackTrace() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        // Default: No debug flag -> only error message, no Java stack trace
+        int code = execute(new String[]{"format", "non_existent_file.oml"}, "", out, err);
+        assertEquals(2, code);
+        String errStr = err.toString(StandardCharsets.UTF_8);
+        assertTrue(errStr.contains("Error:"));
+        assertFalse(errStr.contains("	at dev.omnist.cli.Cli"));
+
+        // With --debug -> prints stack trace
+        err.reset();
+        code = execute(new String[]{"format", "non_existent_file.oml", "--debug"}, "", out, err);
+        assertEquals(2, code);
+        String errDebug = err.toString(StandardCharsets.UTF_8);
+        assertTrue(errDebug.contains("Error:"));
+        assertTrue(errDebug.contains("	at dev.omnist.cli.Cli"));
+
+        // With -v -> prints stack trace
+        err.reset();
+        code = execute(new String[]{"format", "non_existent_file.oml", "-v"}, "", out, err);
+        assertEquals(2, code);
+        String errV = err.toString(StandardCharsets.UTF_8);
+        assertTrue(errV.contains("Error:"));
+        assertTrue(errV.contains("	at dev.omnist.cli.Cli"));
+    }
+
 }


### PR DESCRIPTION
Fixes #53.

- Rejected unrecognized options and missing option values with exit code 2 and explicit error messages instead of silently skipping them.
- Gated JVM stack traces behind `--debug` and `-v` flags; default error messages emit only the message string on stderr.
- Updated `docs/02-cli-reference.md` to document the global options including `--debug` and `-v`.
- Added test coverage in `CliCoverageTest` for unrecognized options, missing option arguments, and stack trace gating.