### PR TITLE
Map OsdLexer lexical errors to normative parse.* codes (#70)

### DIFF
--- a/src/main/java/dev/omnist/schema/OsdLexer.java
+++ b/src/main/java/dev/omnist/schema/OsdLexer.java
@@ -143,7 +143,7 @@ public class OsdLexer {
             return new Token(TokenType.IDENT, text, startLine, startCol);
         }
 
-        throw new OsdParseException(startLine, startCol, "Unexpected character: '" + c + "'");
+        throw new OsdParseException(startLine, startCol, "parse.unexpected-token", "$", "Unexpected character: '" + c + "'");
     }
 
     private void skipHSpaceCommentsAndNewlines() {
@@ -171,7 +171,7 @@ public class OsdLexer {
             }
             if (c == '\\') {
                 if (pos >= source.length()) {
-                    throw new OsdParseException(line, col, "Unterminated escape in string");
+                    throw new OsdParseException(line, col, "parse.unterminated-string", "$", "Unterminated escape in string");
                 }
                 char esc = consumeChar();
                 // OSD §5.3.1: replaces every \X with single character X (no named-escape table)
@@ -180,7 +180,7 @@ public class OsdLexer {
                 sb.append(c);
             }
         }
-        throw new OsdParseException(startLine, startCol, "Unterminated double-quoted string");
+        throw new OsdParseException(startLine, startCol, "parse.unterminated-string", "$", "Unterminated double-quoted string");
     }
 
     private String parseBracketText(int startLine, int startCol) {
@@ -193,7 +193,7 @@ public class OsdLexer {
             }
             sb.append(c);
         }
-        throw new OsdParseException(startLine, startCol, "Unterminated bracket ']' in cardinality");
+        throw new OsdParseException(startLine, startCol, "parse.unexpected-token", "$", "Unterminated bracket ']' in cardinality");
     }
 
     private char consumeChar() {

--- a/src/main/java/dev/omnist/schema/OsdParseException.java
+++ b/src/main/java/dev/omnist/schema/OsdParseException.java
@@ -43,17 +43,7 @@ public class OsdParseException extends RuntimeException {
         this.path = path;
     }
 
-    /**
-     * Constructs a parse exception with default code {@code schema.parse-error} and path {@code "$"}.
-     * Convenience constructor for generic lexical errors from {@link OsdLexer}.
-     *
-     * @param line    1-based line number where the error was detected
-     * @param column  1-based column number where the error was detected
-     * @param message human-readable description of the error
-     */
-    public OsdParseException(int line, int column, String message) {
-        this(line, column, "schema.parse-error", "$", message);
-    }
+
 
     /**
      * Returns the 1-based line number in the OSD source where the error was detected.

--- a/src/test/java/dev/omnist/FinalCoverageTest.java
+++ b/src/test/java/dev/omnist/FinalCoverageTest.java
@@ -73,13 +73,8 @@ class FinalCoverageTest {
         OsdParseException ex = new OsdParseException(5, 10, "code", "path", "msg");
         assertEquals(5, ex.getLine());
         assertEquals(10, ex.getColumn());
-    }
-
-    @Test
-    void osdParseException_threeArgGetters() {
-        OsdParseException ex = new OsdParseException(3, 7, "short msg");
-        assertEquals(3, ex.getLine());
-        assertEquals(7, ex.getColumn());
+        assertEquals("code", ex.getCode());
+        assertEquals("path", ex.getPath());
     }
 
     // ==========================================================================

--- a/src/test/java/dev/omnist/schema/OsdReaderTest.java
+++ b/src/test/java/dev/omnist/schema/OsdReaderTest.java
@@ -176,4 +176,28 @@ class OsdReaderTest {
         // Unknown type reference
         assertThrows(OsdParseException.class, () -> OsdReader.read("record R { \"a\": NonExistent } root R"));
     }
+
+    @Test
+    @DisplayName("OsdLexer lexical error paths produce normative parse.* codes")
+    void testLexerNormativeParseCodes() {
+        // Line 146: Unexpected character -> parse.unexpected-token
+        OsdParseException ex1 = assertThrows(OsdParseException.class, () -> OsdReader.read("record R { @ } root R"));
+        assertEquals("parse.unexpected-token", ex1.getCode());
+        assertEquals("$", ex1.getPath());
+
+        // Line 174: Unterminated escape in string -> parse.unterminated-string
+        OsdParseException ex2 = assertThrows(OsdParseException.class, () -> new OsdLexer("\"abc\\").tokenizeAll());
+        assertEquals("parse.unterminated-string", ex2.getCode());
+        assertEquals("$", ex2.getPath());
+
+        // Line 183: Unterminated double-quoted string -> parse.unterminated-string
+        OsdParseException ex3 = assertThrows(OsdParseException.class, () -> OsdReader.read("record R { \"unclosed: string } root R"));
+        assertEquals("parse.unterminated-string", ex3.getCode());
+        assertEquals("$", ex3.getPath());
+
+        // Line 196: Unterminated bracket in cardinality -> parse.unexpected-token
+        OsdParseException ex4 = assertThrows(OsdParseException.class, () -> new OsdLexer("record R { \"a\" [1,2").tokenizeAll());
+        assertEquals("parse.unexpected-token", ex4.getCode());
+        assertEquals("$", ex4.getPath());
+    }
 }


### PR DESCRIPTION
Migrates OsdLexer call sites from the 3-arg constructor to explicit 5-arg OsdParseException with normative parse.* error codes per omnist-spec Sec8.3.1 (omnist-spec#47), removes the 3-arg constructor, and adds unit tests.\n\nCloses #70.