### PR TITLE
Reject literal control characters in OSD strings

### DIFF
--- a/src/main/java/dev/omnist/schema/OsdLexer.java
+++ b/src/main/java/dev/omnist/schema/OsdLexer.java
@@ -169,6 +169,9 @@ public class OsdLexer {
             if (c == '"') {
                 return sb.toString();
             }
+            if (c < 0x20) {
+                throw new OsdParseException(startLine, startCol, "parse.control-character", "$", "Control characters below U+0020 are forbidden in strings");
+            }
             if (c == '\\') {
                 if (pos >= source.length()) {
                     throw new OsdParseException(line, col, "parse.unterminated-string", "$", "Unterminated escape in string");

--- a/src/test/java/dev/omnist/schema/OsdReaderTest.java
+++ b/src/test/java/dev/omnist/schema/OsdReaderTest.java
@@ -200,4 +200,13 @@ class OsdReaderTest {
         assertEquals("parse.unexpected-token", ex4.getCode());
         assertEquals("$", ex4.getPath());
     }
+
+    @Test
+    @DisplayName("OSD strings forbid literal control characters below U+0020 (issue #72, matching OML's existing rule)")
+    void testOsdStringForbidsLiteralControlCharacter() {
+        String withControlChar = "record R { \"a\": \"xy\" } root R";
+        OsdParseException ex = assertThrows(OsdParseException.class, () -> OsdReader.read(withControlChar));
+        assertEquals("parse.control-character", ex.getCode());
+        assertEquals("$", ex.getPath());
+    }
 }


### PR DESCRIPTION
## Summary
- `parseOsdString` now rejects any raw (non-escaped) character below U+0020 with `parse.control-character`, matching `OmlLexer.parseDQuoteString`'s existing identical check
- omnist-spec commit a575f85 formalized this as normative in §5.3.1 after checking all 5 ports live: Go and TypeScript already independently rejected them, Python/Java/Rust were silently accepting them
- Added a test with a literal U+0001 embedded in an OSD string, asserting the exception code

Closes #72.

## Test plan
- [x] `mvn -q clean test` — exit 0, gate held
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0
- [x] `mvn javadoc:javadoc` — exit 0
