### PR TITLE
Bump version to 0.2.1-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See [`docs/02-cli-reference.md`](docs/02-cli-reference.md) for every subcommand.
 
 ## Status
 
-**`v0.2.0-alpha`** — spec-first, built directly against [`vendor/omnist-spec`](https://github.com/omnist-dev/omnist-spec) (pinned as a git submodule, the normative source of truth for this port's behavior).
+**`v0.2.1-alpha`** — spec-first, built directly against [`vendor/omnist-spec`](https://github.com/omnist-dev/omnist-spec) (pinned as a git submodule, the normative source of truth for this port's behavior).
 
 - **Conformance**: 181/181 (100%) passing against the shared spec test suite, across CLI fixtures and JSON test vectors.
 - **Tests**: 584 passing, 0 failures — JUnit plus jqwik property-based and fuzz testing.

--- a/docs/02-cli-reference.md
+++ b/docs/02-cli-reference.md
@@ -9,7 +9,7 @@
 The CLI executable fat jar can be invoked via:
 
 ```bash
-java -jar target/omnist-j-0.2.0-alpha.jar <command> [subcommand] [options]
+java -jar target/omnist-j-0.2.1-alpha.jar <command> [subcommand] [options]
 ```
 
 Or via `./run-conformance` / shell wrapper `omnist`:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Status and limitations
 
-**`v0.2.0-alpha`.** `omnist-j` implements the full Document model, Schema model, OML and OSD
+**`v0.2.1-alpha`.** `omnist-j` implements the full Document model, Schema model, OML and OSD
 grammars (read and write), `validate`, `materialize`, the full schema
 algebra (`satisfiable_set`, `is_empty`, `prune`, `compatible_with`,
 `equivalent`, `normalize`, `extract`, `lint`, `infer`), all four

--- a/omnist
+++ b/omnist
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # wrapper script for omnist-j CLI
-exec java -jar "$(dirname "$0")/target/omnist-j-0.2.0-alpha.jar" "$@"
+exec java -jar "$(dirname "$0")/target/omnist-j-0.2.1-alpha.jar" "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.omnist</groupId>
     <artifactId>omnist-j</artifactId>
-    <version>0.2.0-alpha</version>
+    <version>0.2.1-alpha</version>
     <name>omnist-j</name>
     <description>Java implementation of the Omnist data-interchange specification</description>
 

--- a/src/main/java/dev/omnist/conformance/Track1Runner.java
+++ b/src/main/java/dev/omnist/conformance/Track1Runner.java
@@ -244,7 +244,7 @@ public final class Track1Runner {
             String stderr = "";
             int exitCode = -1;
 
-            Path omnistJar = repoDir.resolve("target/omnist-j-0.2.0-alpha.jar");
+            Path omnistJar = repoDir.resolve("target/omnist-j-0.2.1-alpha.jar");
             Path omnistBin = repoDir.resolve("omnist");
             if (Files.exists(omnistJar) && Files.exists(omnistBin) && Files.isExecutable(omnistBin)) {
                 try {


### PR DESCRIPTION
## Summary
- Bumps to `0.2.1-alpha` ahead of the first Maven Central release
- Real behavior changes since `0.2.0-alpha`: `OsdParseException`'s lexical error codes now use normative `parse.*` codes instead of the invented `schema.parse-error` (#70), and OSD strings now reject literal control characters below U+0020, matching OML's existing rule (#72)
- Updated all 6 known version-string locations and grepped the exact old string across the repo to confirm zero remaining matches

## Test plan
- [x] `mvn -q clean test` — exit 0
- [x] `mvn -q clean package` — exit 0, produces `target/omnist-j-0.2.1-alpha.jar`
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0 (exercises `Track1Runner.java`'s hardcoded jar-path resolution directly, not just a compile check)
- [x] `mvn javadoc:javadoc` — exit 0
- [x] `./omnist format sample.oml --to json` — ran manually, confirms the wrapper script finds the renamed jar
