### PR TITLE
Prep pom.xml for Maven Central publishing

### DIFF
--- a/docs/workflow-playbook.md
+++ b/docs/workflow-playbook.md
@@ -209,3 +209,33 @@ Every fenced code block in `docs/*.md` requires an HTML-comment marker directly 
 ## 8. Documentation synchronization rule
 
 If a change touches a public API surface, a documented number, or an external-state claim, the documentation describing it MUST be updated in the **same PR** — never left as a follow-up task. Concretely: any PR or commit that adds, modifies, renames, or deprecates a public API class/method in `dev.omnist.*` or a CLI subcommand/flag in `dev.omnist.cli.Cli` MUST update `docs/01-api-reference.md` and/or `docs/02-cli-reference.md` in that same commit — the reflection safeguard in §7 above is the mechanical backstop for this, not a substitute for actually doing it.
+
+---
+
+## 9. Publishing to Maven Central
+
+`mvn clean test`/`mvn package` never require a GPG key or Central credentials — signing and publishing plugins are opt-in via the `release` Maven profile, not bound to the default lifecycle.
+
+**Artifact shape**: the main `dev.omnist:omnist-j` jar is a plain library jar with its real `<dependencies>` intact (Jackson/SnakeYAML/tomlj resolve normally for anyone adding it as a dependency). The shaded fat jar for running `omnist` as a standalone CLI is a separate `-cli` classifier (`omnist-j-<version>-cli.jar`), attached by the same `maven-shade-plugin` execution but never replacing the main artifact. The `omnist` wrapper script and `Track1Runner.java`'s conformance harness both reference the `-cli.jar` explicitly — if either the shade plugin's classifier name or the version changes, update both call sites in the same commit (see §8 above).
+
+**One-time setup** (per releaser, not per machine the CI runs on):
+1. A Sonatype Central Publisher Portal account with the `dev.omnist` namespace verified (a DNS TXT record on `omnist.dev`, not GitHub-based verification, since the groupId is a custom domain, not `io.github.*`).
+2. A GPG signing key, with the public key published to a keyserver (e.g. `gpg --keyserver keyserver.ubuntu.com --send-keys <KEY_ID>`).
+3. A Central Portal user token in `~/.m2/settings.xml`:
+   ```xml
+   <settings>
+     <servers>
+       <server>
+         <id>central</id>
+         <username>TOKEN_USERNAME</username>
+         <password>TOKEN_PASSWORD</password>
+       </server>
+     </servers>
+   </settings>
+   ```
+
+**Releasing**: bump the version first (see the version-string-scatter gotcha above — grep the exact old string repo-wide, don't trust a single-file diff), verify all three gates, then:
+```bash
+mvn clean deploy -Prelease
+```
+This signs and uploads the bundle (main jar, sources jar, javadoc jar, POM) to the Portal. `autoPublish` is deliberately `false` in `pom.xml` — the bundle sits in the Portal for manual review; publishing requires an explicit click there. Central releases are immutable once published: there is no undo, no republish under the same version, and no way to delete a bad release, only supersede it with a new one. Never flip `autoPublish` to `true` without a considered reason to skip that manual checkpoint.

--- a/omnist
+++ b/omnist
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # wrapper script for omnist-j CLI
-exec java -jar "$(dirname "$0")/target/omnist-j-0.2.1-alpha.jar" "$@"
+exec java -jar "$(dirname "$0")/target/omnist-j-0.2.1-alpha-cli.jar" "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,30 @@
     <version>0.2.1-alpha</version>
     <name>omnist-j</name>
     <description>Java implementation of the Omnist data-interchange specification</description>
+    <url>https://j.omnist.dev</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>tomlee</id>
+            <name>Thomas Lee</name>
+            <url>https://github.com/tomlee</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/omnist-dev/omnist-j.git</connection>
+        <developerConnection>scm:git:git@github.com:omnist-dev/omnist-j.git</developerConnection>
+        <url>https://github.com/omnist-dev/omnist-j</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
@@ -203,6 +227,18 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <!--
+                                Attached as a separate "cli" classifier rather than replacing the
+                                main artifact: the main dev.omnist:omnist-j jar must stay a plain
+                                library jar with its real <dependencies> intact for anyone adding
+                                it as a Maven/Gradle dependency, so Jackson/SnakeYAML/tomlj don't
+                                get silently duplicated on their classpath. The fat jar is only for
+                                running `omnist` as a standalone CLI (see the wrapper script and
+                                Track1Runner.java's conformance harness, both of which reference
+                                the -cli.jar explicitly).
+                            -->
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>cli</shadedClassifierName>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>dev.omnist.cli.CliMain</mainClass>
@@ -213,6 +249,82 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--
+            Signing and Central publishing are opt-in via `mvn -Prelease ...` rather than
+            bound to the default lifecycle, so ordinary `mvn clean test`/`mvn package` (what
+            CI and every contributor runs) never requires a GPG key to be present. Activate
+            with `mvn clean deploy -Prelease` once ~/.m2/settings.xml has the `central` server
+            credentials (see docs/workflow-playbook.md) and a GPG key is available locally.
+        -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.10.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.7</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <!--
+                                Manual review before publish: the bundle uploads to the Portal
+                                but requires an explicit click there to actually release. Flip to
+                                true only once confident enough in the release process to skip
+                                that manual check; Central releases are immutable, there is no
+                                undo after publish.
+                            -->
+                            <autoPublish>false</autoPublish>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/dev/omnist/conformance/Track1Runner.java
+++ b/src/main/java/dev/omnist/conformance/Track1Runner.java
@@ -244,7 +244,7 @@ public final class Track1Runner {
             String stderr = "";
             int exitCode = -1;
 
-            Path omnistJar = repoDir.resolve("target/omnist-j-0.2.1-alpha.jar");
+            Path omnistJar = repoDir.resolve("target/omnist-j-0.2.1-alpha-cli.jar");
             Path omnistBin = repoDir.resolve("omnist");
             if (Files.exists(omnistJar) && Files.exists(omnistBin) && Files.isExecutable(omnistBin)) {
                 try {


### PR DESCRIPTION
## Summary
- Adds Central-required POM metadata (`url`, `licenses`, `developers`, `scm`)
- Adds a `release` Maven profile (opt-in via `mvn -Prelease`, never bound to the default lifecycle) that attaches sources/javadoc jars, GPG-signs artifacts, and configures `central-publishing-maven-plugin` with `autoPublish=false` (manual review before going live — Central releases are immutable)
- Splits the shaded fat jar from the main artifact: main `dev.omnist:omnist-j` is now a plain library jar with real `<dependencies>` intact (no more silently bundling Jackson/SnakeYAML/tomlj for anyone adding this as a dependency). The fat jar moves to a `-cli` classifier for direct CLI use — updated the `omnist` wrapper script and `Track1Runner.java`'s conformance harness to the new classifier
- Documented the one-time setup + release procedure in `docs/workflow-playbook.md` §9

## Test plan
- [x] `mvn -q clean test` — exit 0, unaffected by the release profile
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0 (verifies `Track1Runner.java`'s updated `-cli.jar` path resolution actually works, not just compiles)
- [x] `mvn javadoc:javadoc` — exit 0
- [x] `./omnist format sample.oml --to json` — ran manually against the new `-cli.jar`
- [x] `mvn -q clean package` — confirms all 3 non-release artifacts (main 191KB, sources, cli 3.5MB) build with the expected size split
- [x] `mvn -Prelease clean verify` — confirms all 4 release artifacts (main, sources, javadoc, cli) build and the pipeline correctly reaches GPG signing (fails only because this CI/dev box has no `gpg` binary, not a config error)
