### PR TITLE
Automate release tagging on version-bump merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,39 @@ jobs:
         with:
           scan-args: |-
             --lockfile=pom.xml
+
+  auto-tag:
+    # Only on a real push to main (never on PRs, where pushing a tag would be
+    # both wrong and impossible with a read-only PR token). Tagging here only
+    # starts release.yml's verify job and its own redundant test run -- the
+    # actual `mvn deploy -Prelease` still waits on manual approval in the
+    # central-publish environment, so this can't publish anything by itself.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test-and-coverage, conformance]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Tag if pom.xml version is new
+        run: |
+          VERSION="$(mvn -q help:evaluate -Dexpression=project.version -DforceStdout)"
+          TAG="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists, nothing to do."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+          fi

--- a/docs/workflow-playbook.md
+++ b/docs/workflow-playbook.md
@@ -240,9 +240,6 @@ If a change touches a public API surface, a documented number, or an external-st
 
    Delete `private-key.asc` locally once it's in GitHub Secrets — it shouldn't be left sitting on disk, committed, or shared anywhere else.
 
-**Releasing, once the above is set up**: bump the version first (see the version-string-scatter gotcha above — grep the exact old string repo-wide, don't trust a single-file diff), verify all three gates locally, merge to `main`, then tag and push:
-```bash
-git tag v0.2.1-alpha
-git push origin v0.2.1-alpha
-```
-Watch the `Release` workflow run in the Actions tab, and do the final manual review/publish click in the Central Portal once the `publish` job succeeds.
+**Releasing, once the above is set up**: bump the version first (see the version-string-scatter gotcha above — grep the exact old string repo-wide, don't trust a single-file diff), verify all three gates locally, and merge to `main`. Tagging is automatic from there: `ci.yml`'s `auto-tag` job runs on every push to `main` (never on PRs), reads `pom.xml`'s version with `mvn help:evaluate`, and pushes `v<version>` as a tag if that tag doesn't already exist — which is what actually triggers `release.yml`. There is nothing else to run manually to kick off a release; merging the version bump is the trigger.
+
+Two safety properties this depends on: `auto-tag` only fires after `test-and-coverage` and `conformance` both pass (`needs: [...]`), and pushing the tag doesn't publish anything by itself — `release.yml`'s `publish` job still waits on manual approval in the `central-publish` GitHub Environment (required reviewers configured there) before `mvn deploy -Prelease` actually runs. Watch the `Release` workflow in the Actions tab, approve the `publish` job when it's ready, then do the final manual review/publish click in the Central Portal once that job succeeds.


### PR DESCRIPTION
## Summary
- Adds an `auto-tag` job to `ci.yml`: on a real push to `main` (not PRs), after `test-and-coverage`/`conformance` pass, reads `pom.xml`'s version and pushes `v<version>` as a tag if it doesn't already exist
- That tag push is what triggers `release.yml` — merging a version-bump PR is now the entire release trigger, no manual `git tag && git push` step needed
- Doesn't weaken any safety net: `release.yml`'s `publish` job still requires manual approval in the `central-publish` environment (required reviewers already configured there), and `autoPublish` stays `false` so the Central Portal bundle still needs an explicit review click

**Heads up**: merging this PR itself will fire the first real tag (`v0.2.1-alpha`, confirmed not to exist yet), which kicks off `release.yml`'s `verify` job automatically. The `publish` job after that will pause waiting for your approval.

## Test plan
- [x] `.github/workflows/ci.yml` parses as valid YAML
- [x] Verified the version-check command directly — `mvn -q help:evaluate -Dexpression=project.version -DforceStdout` correctly prints `0.2.1-alpha`
- [x] Confirmed no `v0.2.1-alpha` tag exists locally or on `origin` yet
- [x] `mvn -q clean test` — exit 0
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0
