### PR TITLE
Fix release.yml never triggering after auto-tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,7 +75,9 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Tag if pom.xml version is new
+      - name: Tag if pom.xml version is new, and dispatch the Release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="$(mvn -q help:evaluate -Dexpression=project.version -DforceStdout)"
           TAG="v$VERSION"
@@ -85,4 +88,8 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git tag -a "$TAG" -m "Release $TAG"
             git push origin "$TAG"
+            # A tag pushed with the default GITHUB_TOKEN doesn't fire release.yml's
+            # own `push: tags:` trigger (GitHub suppresses workflow-triggered-by-
+            # workflow push events to prevent loops) -- dispatch it explicitly instead.
+            gh workflow run release.yml --ref "$TAG" -f tag="$TAG"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - "v*"
+  # A tag pushed by the ci.yml auto-tag job (using the default GITHUB_TOKEN)
+  # deliberately does NOT fire the `push: tags:` trigger above -- GitHub
+  # suppresses workflow-triggered-by-workflow events via the default token to
+  # prevent infinite loops. auto-tag explicitly dispatches this workflow via
+  # `gh workflow run release.yml --ref <tag>` right after pushing, which is
+  # the standard workaround; this trigger is what makes that dispatch valid.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.2.1-alpha)"
+        required: true
 
 jobs:
   verify:


### PR DESCRIPTION
## Summary
- Merging #79 revealed a real gap: `auto-tag` successfully pushed `v0.2.1-alpha`, but `release.yml`'s `push: tags: v*` trigger never fired — a known GitHub Actions behavior where a push made with the default `GITHUB_TOKEN` deliberately doesn't trigger other workflows (loop prevention)
- Fix: added `workflow_dispatch` to `release.yml`, and `auto-tag` now explicitly runs `gh workflow run release.yml --ref "$TAG"` after pushing, the standard workaround for this exact limitation
- Needed `actions: write` added to `auto-tag`'s job permissions (alongside the existing `contents: write`) to allow dispatching another workflow

## Test plan
- [x] Both workflow YAML files parse correctly
- [x] `mvn -q clean test` — exit 0
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0
- [ ] End-to-end verification happens on merge (or by manually dispatching `release.yml --ref v0.2.1-alpha` against the already-pushed tag) — noting here rather than claiming it in advance
