### PR TITLE
Bump central-publishing-maven-plugin to fix status-polling crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## Summary
- Bumps `central-publishing-maven-plugin` `0.7.0` -> `0.11.0`
- The first real release attempt got past signature verification but crashed on this plugin's own status-polling step: `UnrecognizedPropertyException: Unrecognized field "warnings"` — Central's API added a field the old client's response model doesn't know about and isn't configured to ignore. The actual upload had already succeeded by that point; only the client's parsing of the follow-up status call crashed.

Note: `pom.xml`'s `<version>` is unchanged (still `0.2.1-alpha`), so merging this won't create a new tag — `auto-tag` will correctly no-op since `v0.2.1-alpha` already exists. The release will be re-dispatched manually against the existing tag.

## Test plan
- [x] `mvn -q clean test` — exit 0
- [x] `./run-conformance` — Pass: 181, Fail: 0, Skip: 0
- [x] `mvn -Prelease validate` — resolves the new plugin version cleanly
