### PR TITLE
Fix #82: reject duplicate root declarations (schema.duplicate-root)

### DIFF
--- a/src/main/java/dev/omnist/schema/OsdReader.java
+++ b/src/main/java/dev/omnist/schema/OsdReader.java
@@ -69,7 +69,7 @@ public class OsdReader {
             } else if (t.type() == TokenType.ROOT) {
                 consumeToken(); // consume 'root'
                 if (rootName != null) {
-                    throw new OsdParseException(t.line(), t.col(), "schema.no-root", "$", "Duplicate root declaration");
+                    throw new OsdParseException(t.line(), t.col(), "schema.duplicate-root", "$", "Duplicate root declaration");
                 }
                 Token nameTok = peekToken();
                 if (nameTok.type() != TokenType.IDENT) {

--- a/src/test/java/dev/omnist/FinalCoverageTest.java
+++ b/src/test/java/dev/omnist/FinalCoverageTest.java
@@ -103,8 +103,10 @@ class FinalCoverageTest {
     @Test
     void osdReader_duplicateRootThrows() {
         // line 42: duplicate root
-        assertThrows(OsdParseException.class,
+        OsdParseException ex = assertThrows(OsdParseException.class,
             () -> OsdReader.read("record R { \"x\": string }\nroot R\nroot R\n"));
+        assertEquals("schema.duplicate-root", ex.getCode());
+        assertEquals("$", ex.getPath());
     }
 
     @Test

--- a/src/test/java/dev/omnist/conformance/ConformanceTest.java
+++ b/src/test/java/dev/omnist/conformance/ConformanceTest.java
@@ -34,7 +34,7 @@ class ConformanceTest {
         int[] results = Track2Runner.runTrack2(testSuitePath);
         assertNotNull(results);
         assertEquals(3, results.length);
-        assertEquals(152, results[0], "Track 2 should pass all 152 real JSON test vectors");
+        assertEquals(153, results[0], "Track 2 should pass all 153 real JSON test vectors");
         assertEquals(0, results[1], "Track 2 should have 0 failures");
         assertEquals(0, results[2], "Track 2 should have 0 skips");
     }

--- a/src/test/java/dev/omnist/schema/OsdReaderTest.java
+++ b/src/test/java/dev/omnist/schema/OsdReaderTest.java
@@ -168,7 +168,10 @@ class OsdReaderTest {
         assertThrows(OsdParseException.class, () -> OsdReader.read("record R { \"a\": string }"));
 
         // Duplicate root
-        assertThrows(OsdParseException.class, () -> OsdReader.read("record R { \"a\": string } root R root R"));
+        OsdParseException dupRoot = assertThrows(OsdParseException.class,
+            () -> OsdReader.read("record R { \"a\": string } root R root R"));
+        assertEquals("schema.duplicate-root", dupRoot.getCode());
+        assertEquals("$", dupRoot.getPath());
 
         // Duplicate record definition
         assertThrows(OsdParseException.class, () -> OsdReader.read("record R { \"a\": string } record R { \"b\": string } root R"));


### PR DESCRIPTION
## Summary

Closes #82.

Per omnist-spec Sec5.8 (D-2, closed at `964af7b`), an OSD schema with more
than one `root` declaration is now a normative error — `schema.duplicate-root`
at path `$` — rather than implementation-defined "last root wins" behavior.

`OsdReader.parseSchema` already threw on a second `root` declaration, but
tagged the error with the wrong code (`schema.no-root`, copy-pasted from a
neighboring branch). It now raises `schema.duplicate-root`, matching the
spec's new conformance vector `osd-grammar/root/duplicate-root-is-an-error`.

This is a real behavior change in the sense that the *error code* changes
for this input (a schema with two `root` declarations was already rejected,
just under the wrong code) — no previously-accepted document is now
rejected, since a document with two roots already failed to parse before
this change. Grepped the codebase for any "last root wins" / last-write
logic; found none.

## Changes

- `vendor/omnist-spec`: bumped to `964af7b` (adds the `duplicate-root`
  conformance vector; pinned exactly rather than following `master` further
  to avoid pulling in unrelated D-3 changes).
- `src/main/java/dev/omnist/schema/OsdReader.java`: second `root`
  declaration now raises `schema.duplicate-root` (was `schema.no-root`).
- `src/test/java/dev/omnist/schema/OsdReaderTest.java` and
  `FinalCoverageTest.java`: tightened the existing duplicate-root tests to
  assert on `getCode()`/`getPath()` instead of just the exception type.
- `src/test/java/dev/omnist/conformance/ConformanceTest.java`: Track 2
  real-vector count bumped 152 -> 153 to reflect the new vector.

## Test plan

- [x] `mvn test` — all tests pass (584 total, including the tightened
      duplicate-root assertions and the new conformance vector via
      `ConformanceTest`).
- [x] `mvn verify` — passes, including the JaCoCo coverage gate.
- [x] Confirmed no code path depends on "last root wins" semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
