### PR TITLE
Document Maven Central install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,30 @@ A from-scratch Java implementation of [Omnist](https://github.com/omnist-dev/omn
 
 Full docs: [j.omnist.dev](https://j.omnist.dev) · Javadoc: [j.omnist.dev/javadoc](https://j.omnist.dev/javadoc/)
 
+## Installing
+
+Available on [Maven Central](https://central.sonatype.com/artifact/dev.omnist/omnist-j) as `dev.omnist:omnist-j`.
+
+**Maven:**
+```xml
+<dependency>
+    <groupId>dev.omnist</groupId>
+    <artifactId>omnist-j</artifactId>
+    <version>0.2.1-alpha</version>
+</dependency>
+```
+
+**Gradle:**
+```groovy
+implementation 'dev.omnist:omnist-j:0.2.1-alpha'
+```
+
+This is a plain library jar with its real dependencies (Jackson, SnakeYAML, tomlj) resolved normally — nothing bundled or shaded. If you want to run `omnist` as a standalone CLI instead of using it as a library, use the `cli` classifier, which is a self-contained fat jar:
+```bash
+curl -O https://repo1.maven.org/maven2/dev/omnist/omnist-j/0.2.1-alpha/omnist-j-0.2.1-alpha-cli.jar
+java -jar omnist-j-0.2.1-alpha-cli.jar format sample.oml --to json
+```
+
 ## Quickstart
 
 ```java
@@ -69,7 +93,7 @@ See [`docs/02-cli-reference.md`](docs/02-cli-reference.md) for every subcommand.
 
 **`v0.2.1-alpha`** — spec-first, built directly against [`vendor/omnist-spec`](https://github.com/omnist-dev/omnist-spec) (pinned as a git submodule, the normative source of truth for this port's behavior).
 
-- **Conformance**: 181/181 (100%) passing against the shared spec test suite, across CLI fixtures and JSON test vectors.
+- **Conformance**: 182/182 (100%) passing against the shared spec test suite, across CLI fixtures and JSON test vectors.
 - **Tests**: 584 passing, 0 failures — JUnit plus jqwik property-based and fuzz testing.
 - **Coverage**: 99.83% line / 99.75% branch (gated in CI). Every remaining gap is a documented, verified trip-wire, not an untested code path — see [`docs/limitations.md`](docs/limitations.md) for the full breakdown and why each one is unreachable.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -8,7 +8,7 @@ interchange codecs (JSON/YAML/TOML/XML, read and write), and a CLI.
 
 ## Conformance
 
-Both tracks of the conformance harness pass at **181 / 181 (100%)** —
+Both tracks of the conformance harness pass at **182 / 182 (100%)** —
 Track 1 CLI fixtures and Track 2 JSON test vectors, run against
 `vendor/omnist-spec`'s pinned `test-suite/`. Zero fails, zero skips.
 


### PR DESCRIPTION
## Summary
- `dev.omnist:omnist-j:0.2.1-alpha` is live on Maven Central. Added a README "Installing" section with Maven/Gradle dependency snippets, plus the `curl`+`java -jar` invocation for the standalone `-cli` classifier
- Refreshed the conformance count (181 -> 182) in README.md and docs/limitations.md — the vendored omnist-spec submodule advanced upstream and added a vector since these numbers were last measured

## Test plan
- [x] `mvn dependency:resolve` against a real throwaway project with `dev.omnist:omnist-j:0.2.1-alpha` as a dependency — resolves cleanly, exit 0
- [x] Downloaded the real `-cli.jar` from `repo1.maven.org` and ran the exact command from the README against a sample file — produced correct output
- [x] `mvn -q clean test` — exit 0
- [x] `./run-conformance` — Pass: 182, Fail: 0, Skip: 0
