### PR TITLE
Report format.attribute-dropped, format.namespace-dropped, format.interleaving-lost (D-3)

### DIFF
--- a/src/main/java/dev/omnist/codec/JsonCodec.java
+++ b/src/main/java/dev/omnist/codec/JsonCodec.java
@@ -229,15 +229,21 @@ public final class JsonCodec {
      */
     public static WriteReport check(Document node) {
         WriteReport rep = new WriteReport();
-        scanJson(node, "$", 0, rep);
+        scanJson(node, "$", 0, rep, new boolean[]{false});
         return rep;
     }
 
-    private static void scanJson(Document doc, String path, int depth, WriteReport rep) {
+    private static void scanJson(Document doc, String path, int depth, WriteReport rep, boolean[] interleavingFound) {
         if (depth > 200) {
             throw new WriteException("nesting exceeds the maximum depth (200)");
         }
         if (doc instanceof Node node) {
+            if (!interleavingFound[0] && dev.omnist.document.PathUtils.hasInterleavedLabels(node)) {
+                rep.add("$", "format.interleaving-lost",
+                        "cross-label edge interleaving cannot be represented; grouping same-label edges together lost the original relative order",
+                        "warning");
+                interleavingFound[0] = true;
+            }
             Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(node);
             Map<String, Integer> seen = new HashMap<>();
             for (Edge edge : node.edges()) {
@@ -246,7 +252,7 @@ public final class JsonCodec {
                 seen.put(label, i + 1);
                 int total = totals.getOrDefault(label, 1);
                 String p = dev.omnist.document.PathUtils.childPath(path, label, i, total);
-                scanJson((Document) edge.target(), p, depth + 1, rep);
+                scanJson((Document) edge.target(), p, depth + 1, rep, interleavingFound);
             }
         } else if (doc instanceof Scalar s) {
             if (s instanceof DateScalar || s instanceof TimeScalar || s instanceof DateTimeScalar) {

--- a/src/main/java/dev/omnist/codec/TomlCodec.java
+++ b/src/main/java/dev/omnist/codec/TomlCodec.java
@@ -593,15 +593,25 @@ public final class TomlCodec {
         if (!(node instanceof dev.omnist.document.Node)) {
             return rep;
         }
-        stripNulls(node, "$", rep, 0);
+        stripNulls(node, "$", rep, 0, new boolean[]{false});
         return rep;
     }
 
     private static Document stripNulls(Document doc, String path, WriteReport rep, int depth) {
+        return stripNulls(doc, path, rep, depth, new boolean[]{false});
+    }
+
+    private static Document stripNulls(Document doc, String path, WriteReport rep, int depth, boolean[] interleavingFound) {
         if (depth > 200) {
             throw new WriteException("nesting exceeds the maximum depth (200)");
         }
         if (doc instanceof dev.omnist.document.Node node) {
+            if (!interleavingFound[0] && dev.omnist.document.PathUtils.hasInterleavedLabels(node)) {
+                rep.add("$", "format.interleaving-lost",
+                        "cross-label edge interleaving cannot be represented; grouping same-label edges together lost the original relative order",
+                        "warning");
+                interleavingFound[0] = true;
+            }
             List<Edge> edges = new ArrayList<>();
             Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(node);
             Map<String, Integer> seen = new HashMap<>();
@@ -616,7 +626,7 @@ public final class TomlCodec {
                     rep.add(p, "format.null-unrepresentable", "null value dropped (TOML has no null)", "warning");
                     continue;
                 }
-                edges.add(new Edge(label, (Target) stripNulls(child, p, rep, depth + 1)));
+                edges.add(new Edge(label, (Target) stripNulls(child, p, rep, depth + 1, interleavingFound)));
             }
             return new dev.omnist.document.Node(edges);
         }

--- a/src/main/java/dev/omnist/codec/XmlCodec.java
+++ b/src/main/java/dev/omnist/codec/XmlCodec.java
@@ -23,9 +23,10 @@ import java.util.regex.Pattern;
  * becomes the sole top-level edge; child elements become nested edges, preserving
  * repeated-element order (this is the one codec where cross-label interleaving both
  * reads and writes faithfully — every other codec's writer groups same-label edges).
- * Attribute and namespace-prefix information is discarded on read, silently per
- * omnist-spec §9.4 D-3 (no diagnostic is emitted for this — it's a spec-mandated
- * lossy conversion, not an oversight).
+ * Attribute and namespace-prefix information is discarded on read; each drop is
+ * reported via {@code format.attribute-dropped}/{@code format.namespace-dropped}
+ * (omnist-spec §8.3.8, closing §9.4 D-3) when a {@link WriteReport} is supplied
+ * to {@link #read(String, Schema, WriteReport)}.
  *
  * <p><b>Writing</b>: scalar leaves are stringified per XML's own type rules
  * ({@link #XML_INT_RE}/{@link #XML_NUM_RE}); a leaf label that isn't a legal XML
@@ -54,7 +55,7 @@ public final class XmlCodec {
      * @throws RuntimeException if the XML is not well-formed or exceeds {@link #MAX_INPUT_LENGTH}
      */
     public static Document read(String text) {
-        return read(text, null);
+        return read(text, null, null);
     }
 
     /**
@@ -79,6 +80,28 @@ public final class XmlCodec {
      * @throws RuntimeException if the XML is not well-formed or exceeds {@link #MAX_INPUT_LENGTH}
      */
     public static Document read(String text, Schema schema) {
+        return read(text, schema, null);
+    }
+
+    /**
+     * Parses XML text into a {@link Document}, optionally with schema guidance and a
+     * read-side diagnostic report.
+     *
+     * <p>Unlike write-side {@code format.*} adjustments, XML read never fails or coerces
+     * because of a read-side adjustment; {@code report}, when non-{@code null}, simply
+     * accumulates a warning for each lossy conversion the read had to make (omnist-spec
+     * Sec8.3.8's {@code format.attribute-dropped} and {@code format.namespace-dropped}):
+     * an element's attributes have no Document representation and are discarded, and a
+     * namespace-prefixed tag ({@code <ns:b>}) is read as its local name ({@code b}),
+     * discarding the prefix and any namespace binding.
+     *
+     * @param text   the XML text; must not be {@code null}
+     * @param schema if non-{@code null}, guides scalar-kind resolution as described above
+     * @param report if non-{@code null}, every read-side adjustment is appended here
+     * @return the parsed document
+     * @throws RuntimeException if the XML is not well-formed or exceeds {@link #MAX_INPUT_LENGTH}
+     */
+    public static Document read(String text, Schema schema, WriteReport report) {
         if (text == null) {
             throw new IllegalArgumentException("input text cannot be null");
         }
@@ -89,7 +112,7 @@ public final class XmlCodec {
         org.w3c.dom.Element rootElem;
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            dbf.setNamespaceAware(true);
+            dbf.setNamespaceAware(false);
             dbf.setCoalescing(true);
 
             // Secure configuration to block XXE / DTD expansion
@@ -108,8 +131,12 @@ public final class XmlCodec {
         }
 
         int[] budget = new int[]{0};
+        WriteReport rep = new WriteReport();
         String rootLabel = localName(rootElem);
-        Object rootContent = xmlToNode(rootElem, "$", 0, budget);
+        Object rootContent = xmlToNode(rootElem, "$", "$." + rootLabel, 0, budget, rep);
+        if (report != null) {
+            report.addAll(rep.adjustments());
+        }
 
         if (schema != null) {
             Object rootType = schema.records().get(schema.root());
@@ -144,10 +171,29 @@ public final class XmlCodec {
         return rootElem;
     }
 
-    private static Object xmlToNode(org.w3c.dom.Element elem, String path, int depth, int[] budget) {
+    private static Object xmlToNode(org.w3c.dom.Element elem, String path, String docPath, int depth, int[] budget, WriteReport rep) {
         Limits limits = Limits.DEFAULT;
         if (depth > limits.maxDepth()) {
             throw new DocumentParseException(path, "document.limit.depth", path + ": nesting exceeds the maximum depth (" + limits.maxDepth() + ")");
+        }
+
+        int prefixColon = elem.getTagName().indexOf(':');
+        if (prefixColon >= 0) {
+            rep.add(docPath, "format.namespace-dropped",
+                    "namespace prefix '" + elem.getTagName().substring(0, prefixColon) + "' discarded on read; element read as local name '" + localName(elem) + "' with no namespace binding",
+                    "warning");
+        }
+        org.w3c.dom.NamedNodeMap attrs = elem.getAttributes();
+        for (int i = 0; i < attrs.getLength(); i++) {
+            org.w3c.dom.Attr attr = (org.w3c.dom.Attr) attrs.item(i);
+            String attrName = attr.getName();
+            if (attrName.equals("xmlns") || attrName.startsWith("xmlns:")) {
+                continue;
+            }
+            rep.add(docPath, "format.attribute-dropped",
+                    "attribute discarded on read (no Document path can represent an XML attribute)",
+                    "warning");
+            break;
         }
 
         List<org.w3c.dom.Element> childElements = new ArrayList<>();
@@ -184,7 +230,7 @@ public final class XmlCodec {
             List<Object[]> edges = new ArrayList<>();
             for (org.w3c.dom.Element c : childElements) {
                 String localName = localName(c);
-                Object childNode = xmlToNode(c, path + "." + localName, depth + 1, budget);
+                Object childNode = xmlToNode(c, path + "." + localName, docPath + "." + localName, depth + 1, budget, rep);
                 edges.add(new Object[]{localName, childNode});
             }
             return edges;
@@ -201,10 +247,10 @@ public final class XmlCodec {
     }
 
     private static String localName(org.w3c.dom.Element el) {
-        String name = el.getLocalName();
-        if (name == null) {
-            name = el.getTagName();
-        }
+        // The DocumentBuilderFactory is deliberately non-namespace-aware (see #read),
+        // so getLocalName() always returns null here -- getTagName() (the raw,
+        // possibly-prefixed tag text) is the only source, with any prefix stripped below.
+        String name = el.getTagName();
         int colon = name.indexOf(':');
         if (colon >= 0) {
             name = name.substring(colon + 1);

--- a/src/main/java/dev/omnist/codec/YamlCodec.java
+++ b/src/main/java/dev/omnist/codec/YamlCodec.java
@@ -282,15 +282,21 @@ public final class YamlCodec {
      */
     public static WriteReport check(Document node) {
         WriteReport rep = new WriteReport();
-        scanYaml(node, "$", 0, rep);
+        scanYaml(node, "$", 0, rep, new boolean[]{false});
         return rep;
     }
 
-    private static void scanYaml(Document doc, String path, int depth, WriteReport rep) {
+    private static void scanYaml(Document doc, String path, int depth, WriteReport rep, boolean[] interleavingFound) {
         if (depth > 200) {
             throw new WriteException("nesting exceeds the maximum depth (200)");
         }
         if (doc instanceof dev.omnist.document.Node node) {
+            if (!interleavingFound[0] && dev.omnist.document.PathUtils.hasInterleavedLabels(node)) {
+                rep.add("$", "format.interleaving-lost",
+                        "cross-label edge interleaving cannot be represented; grouping same-label edges together lost the original relative order",
+                        "warning");
+                interleavingFound[0] = true;
+            }
             Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(node);
             Map<String, Integer> seen = new HashMap<>();
             for (Edge edge : node.edges()) {
@@ -302,7 +308,7 @@ public final class YamlCodec {
                 seen.put(label, i + 1);
                 int total = totals.getOrDefault(label, 1);
                 String p = dev.omnist.document.PathUtils.childPath(path, label, i, total);
-                scanYaml((Document) edge.target(), p, depth + 1, rep);
+                scanYaml((Document) edge.target(), p, depth + 1, rep, interleavingFound);
             }
         } else if (doc instanceof Scalar s) {
             if (s instanceof TimeScalar) {

--- a/src/main/java/dev/omnist/conformance/Track2Runner.java
+++ b/src/main/java/dev/omnist/conformance/Track2Runner.java
@@ -143,8 +143,9 @@ public final class Track2Runner {
 
         Document actualDoc = null;
         Throwable thrown = null;
+        WriteReport readReport = new WriteReport();
         try {
-            actualDoc = parseFormat(text, format, limits);
+            actualDoc = parseFormat(text, format, limits, readReport);
         } catch (Throwable ex) {
             thrown = ex;
         }
@@ -156,6 +157,9 @@ public final class Track2Runner {
             Document expectedDoc = decodeJsonDoc(expect.get("document"));
             if (!actualDoc.equals(expectedDoc) && !isEquivalentDoc(actualDoc, expectedDoc)) {
                 throw new RuntimeException("Parsed document does not match expected document");
+            }
+            if (expect.has("diagnostics")) {
+                compareDiagnostics(readReport.adjustments(), expect.get("diagnostics"));
             }
             passCount++;
             System.out.println("    [PASS] parse:" + input.get("text").asText().replace("\n", "\\n"));
@@ -844,6 +848,10 @@ public final class Track2Runner {
     }
 
     private static Document parseFormat(String text, String format, dev.omnist.document.Limits limits) throws Exception {
+        return parseFormat(text, format, limits, null);
+    }
+
+    private static Document parseFormat(String text, String format, dev.omnist.document.Limits limits, WriteReport report) throws Exception {
         if ("oml".equalsIgnoreCase(format)) {
             return dev.omnist.oml.OmlReader.read(text, limits);
         } else if ("json".equalsIgnoreCase(format)) {
@@ -853,7 +861,7 @@ public final class Track2Runner {
         } else if ("toml".equalsIgnoreCase(format)) {
             return dev.omnist.codec.TomlCodec.read(text);
         } else if ("xml".equalsIgnoreCase(format)) {
-            return dev.omnist.codec.XmlCodec.read(text);
+            return dev.omnist.codec.XmlCodec.read(text, null, report);
         } else {
             throw new IllegalArgumentException("Unknown format: " + format);
         }

--- a/src/main/java/dev/omnist/document/PathUtils.java
+++ b/src/main/java/dev/omnist/document/PathUtils.java
@@ -1,7 +1,9 @@
 package dev.omnist.document;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Shared utilities for constructing canonical document paths in diagnostics and report adjustments (omnist-spec §8).
@@ -80,5 +82,40 @@ public final class PathUtils {
             }
         }
         return out;
+    }
+
+    /**
+     * Detects whether grouping {@code node}'s direct child edges by label (the
+     * transform every JSON-family writer -- JSON, YAML, TOML -- applies via
+     * {@link #groupEdges}) would change their relative order: true when two or
+     * more distinct labels are present and at least one label's occurrences are
+     * not all contiguous in the original edge order (omnist-spec {@code
+     * format.interleaving-lost}, Sec8.3.8).
+     *
+     * @param node the node whose direct edges are checked
+     * @return {@code true} if grouping by label loses real cross-label interleaving
+     */
+    public static boolean hasInterleavedLabels(Node node) {
+        java.util.List<Edge> edges = node.edges();
+        Set<String> distinctLabels = new HashSet<>();
+        for (Edge e : edges) {
+            distinctLabels.add(e.label());
+        }
+        if (distinctLabels.size() < 2) {
+            return false;
+        }
+        Set<String> closed = new HashSet<>();
+        String current = null;
+        for (Edge e : edges) {
+            String label = e.label();
+            if (!label.equals(current)) {
+                if (closed.contains(label)) {
+                    return true;
+                }
+                closed.add(label);
+                current = label;
+            }
+        }
+        return false;
     }
 }

--- a/src/test/java/dev/omnist/codec/JsonCodecTest.java
+++ b/src/test/java/dev/omnist/codec/JsonCodecTest.java
@@ -231,4 +231,38 @@ public class JsonCodecTest {
         String json = JsonCodec.write(doc, null, true, null);
         assertNotNull(json);
     }
+
+    @Test
+    @DisplayName("Issue #84 (D-3): cross-label edge interleaving lost by grouping is reported via format.interleaving-lost at $")
+    void testInterleavingLostDiagnostic() {
+        Document doc = new Node(List.of(
+            new Edge("m", new StringScalar("A")),
+            new Edge("x", new StringScalar("X")),
+            new Edge("m", new StringScalar("B"))
+        ));
+        WriteReport report = new WriteReport();
+        JsonCodec.write(doc, null, false, report);
+
+        assertEquals(1, report.adjustments().stream().filter(a -> a.code().equals("format.interleaving-lost")).count());
+        WriteAdjustment adj = report.adjustments().stream()
+            .filter(a -> a.code().equals("format.interleaving-lost"))
+            .findFirst().orElseThrow();
+        assertEquals("$", adj.path());
+        assertEquals("warning", adj.severity());
+    }
+
+    @Test
+    @DisplayName("Issue #84 (D-3): a contiguous repeat of the same label does NOT fire format.interleaving-lost")
+    void testContiguousRepeatDoesNotFireInterleavingLost() {
+        Document doc = new Node(List.of(
+            new Edge("m", new StringScalar("A")),
+            new Edge("m", new StringScalar("B")),
+            new Edge("x", new StringScalar("X"))
+        ));
+        WriteReport report = new WriteReport();
+        JsonCodec.write(doc, null, false, report);
+
+        assertTrue(report.adjustments().stream().noneMatch(a -> a.code().equals("format.interleaving-lost")),
+            "unexpected interleaving-lost for a contiguous repeat: " + report);
+    }
 }

--- a/src/test/java/dev/omnist/codec/TomlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/TomlCodecTest.java
@@ -381,4 +381,38 @@ public class TomlCodecTest {
         assertNotNull(doc);
     }
 
+
+    @Test
+    @DisplayName("Issue #84 (D-3): cross-label edge interleaving lost by grouping is reported via format.interleaving-lost at $")
+    void testInterleavingLostDiagnostic() {
+        Document doc = new Node(List.of(
+            new Edge("m", new StringScalar("A")),
+            new Edge("x", new StringScalar("X")),
+            new Edge("m", new StringScalar("B"))
+        ));
+        WriteReport report = new WriteReport();
+        TomlCodec.write(doc, false, report);
+
+        assertEquals(1, report.adjustments().stream().filter(a -> a.code().equals("format.interleaving-lost")).count());
+        WriteAdjustment adj = report.adjustments().stream()
+            .filter(a -> a.code().equals("format.interleaving-lost"))
+            .findFirst().orElseThrow();
+        assertEquals("$", adj.path());
+        assertEquals("warning", adj.severity());
+    }
+
+    @Test
+    @DisplayName("Issue #84 (D-3): a contiguous repeat of the same label does NOT fire format.interleaving-lost")
+    void testContiguousRepeatDoesNotFireInterleavingLost() {
+        Document doc = new Node(List.of(
+            new Edge("m", new StringScalar("A")),
+            new Edge("m", new StringScalar("B")),
+            new Edge("x", new StringScalar("X"))
+        ));
+        WriteReport report = new WriteReport();
+        TomlCodec.write(doc, false, report);
+
+        assertTrue(report.adjustments().stream().noneMatch(a -> a.code().equals("format.interleaving-lost")),
+            "unexpected interleaving-lost for a contiguous repeat: " + report);
+    }
 }

--- a/src/test/java/dev/omnist/codec/XmlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/XmlCodecTest.java
@@ -359,7 +359,7 @@ public class XmlCodecTest {
     @DisplayName("read/write: budget guards and buildDoc's unknown-type throw (reflection)")
     void testBudgetGuardsAndUnknownTypeViaReflection() throws Exception {
         java.lang.reflect.Method xmlToNode = XmlCodec.class.getDeclaredMethod(
-            "xmlToNode", org.w3c.dom.Element.class, String.class, int.class, int[].class);
+            "xmlToNode", org.w3c.dom.Element.class, String.class, String.class, int.class, int[].class, dev.omnist.codec.WriteReport.class);
         xmlToNode.setAccessible(true);
         javax.xml.parsers.DocumentBuilderFactory dbf = javax.xml.parsers.DocumentBuilderFactory.newInstance();
         org.w3c.dom.Document domDoc = dbf.newDocumentBuilder().parse(
@@ -430,5 +430,85 @@ public class XmlCodecTest {
         // Note: \u0000 is replaced by \uFFFD by xmlSanitize
         String expected = "<>&\"'\uFFFD\t\n<&amp;>";
         assertEquals(expected, ((StringScalar) ((Node) advRound).edges().get(0).target()).value());
+    }
+
+    @Test
+    @DisplayName("Issue #84 (D-3): dropped attribute is reported via format.attribute-dropped at the owning element's path")
+    void testAttributeDroppedDiagnostic() {
+        String xml = "<a x=\"1\"><b>hi</b></a>";
+        WriteReport report = new WriteReport();
+        Document doc = XmlCodec.read(xml, null, report);
+
+        Node root = (Node) doc;
+        assertEquals(1, root.edges().size());
+        assertEquals("a", root.edges().get(0).label());
+        Node aNode = (Node) root.edges().get(0).target();
+        assertEquals(1, aNode.edges().size());
+        assertEquals("b", aNode.edges().get(0).label());
+        assertEquals("hi", ((StringScalar) aNode.edges().get(0).target()).value());
+
+        assertEquals(1, report.adjustments().size());
+        WriteAdjustment adj = report.adjustments().get(0);
+        assertEquals("$.a", adj.path());
+        assertEquals("format.attribute-dropped", adj.code());
+        assertEquals("warning", adj.severity());
+    }
+
+    @Test
+    @DisplayName("Issue #84 (D-3): dropped namespace prefix is reported via format.namespace-dropped at the element's own path")
+    void testNamespaceDroppedDiagnostic() {
+        String xml = "<a><ns:b>hi</ns:b></a>";
+        WriteReport report = new WriteReport();
+        Document doc = XmlCodec.read(xml, null, report);
+
+        Node root = (Node) doc;
+        Node aNode = (Node) root.edges().get(0).target();
+        assertEquals("b", aNode.edges().get(0).label());
+        assertEquals("hi", ((StringScalar) aNode.edges().get(0).target()).value());
+
+        assertEquals(1, report.adjustments().size());
+        WriteAdjustment adj = report.adjustments().get(0);
+        assertEquals("$.a.b", adj.path());
+        assertEquals("format.namespace-dropped", adj.code());
+        assertEquals("warning", adj.severity());
+    }
+
+    @Test
+    @DisplayName("Issue #84 (D-3): read(text) / read(text, schema) with no report still succeed (report is opt-in)")
+    void testReadWithoutReportStillWorks() {
+        assertDoesNotThrow(() -> XmlCodec.read("<a x=\"1\"><b>hi</b></a>"));
+        Schema schema = OsdReader.read("record R { \"b\": string }\nroot R\n");
+        assertDoesNotThrow(() -> XmlCodec.read("<a x=\"1\"><b>hi</b></a>", schema));
+    }
+
+    @Test
+    @DisplayName("a plain (non-prefixed, no-attribute) element produces no D-3 diagnostics")
+    void testNoSpuriousD3Diagnostics() {
+        WriteReport report = new WriteReport();
+        XmlCodec.read("<a><b>hi</b></a>", null, report);
+        assertTrue(report.adjustments().isEmpty(), "unexpected adjustments: " + report);
+    }
+
+    @Test
+    @DisplayName("an xmlns declaration attribute is not itself reported as format.attribute-dropped")
+    void testXmlnsDeclarationNotReportedAsAttributeDropped() {
+        String xml = "<root xmlns:ns='http://example.com'><ns:m>first</ns:m></root>";
+        WriteReport report = new WriteReport();
+        XmlCodec.read(xml, null, report);
+
+        assertTrue(report.adjustments().stream().noneMatch(a -> a.code().equals("format.attribute-dropped")),
+            "xmlns declaration should not be reported as a dropped attribute: " + report);
+        assertTrue(report.adjustments().stream().anyMatch(a -> a.code().equals("format.namespace-dropped")));
+    }
+
+    @Test
+    @DisplayName("a bare default-namespace xmlns attribute (no prefix) is not itself reported as format.attribute-dropped")
+    void testBareDefaultXmlnsNotReportedAsAttributeDropped() {
+        String xml = "<root xmlns='http://example.com'><b>hi</b></root>";
+        WriteReport report = new WriteReport();
+        XmlCodec.read(xml, null, report);
+
+        assertTrue(report.adjustments().stream().noneMatch(a -> a.code().equals("format.attribute-dropped")),
+            "bare xmlns declaration should not be reported as a dropped attribute: " + report);
     }
 }

--- a/src/test/java/dev/omnist/codec/YamlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/YamlCodecTest.java
@@ -246,4 +246,38 @@ public class YamlCodecTest {
         String yaml = YamlCodec.write(doc, true, null);
         assertNotNull(yaml);
     }
+
+    @Test
+    @DisplayName("Issue #84 (D-3): cross-label edge interleaving lost by grouping is reported via format.interleaving-lost at $")
+    void testInterleavingLostDiagnostic() {
+        Document doc = new Node(List.of(
+            new Edge("m", new StringScalar("A")),
+            new Edge("x", new StringScalar("X")),
+            new Edge("m", new StringScalar("B"))
+        ));
+        WriteReport report = new WriteReport();
+        YamlCodec.write(doc, false, report);
+
+        assertEquals(1, report.adjustments().stream().filter(a -> a.code().equals("format.interleaving-lost")).count());
+        WriteAdjustment adj = report.adjustments().stream()
+            .filter(a -> a.code().equals("format.interleaving-lost"))
+            .findFirst().orElseThrow();
+        assertEquals("$", adj.path());
+        assertEquals("warning", adj.severity());
+    }
+
+    @Test
+    @DisplayName("Issue #84 (D-3): a contiguous repeat of the same label does NOT fire format.interleaving-lost")
+    void testContiguousRepeatDoesNotFireInterleavingLost() {
+        Document doc = new Node(List.of(
+            new Edge("m", new StringScalar("A")),
+            new Edge("m", new StringScalar("B")),
+            new Edge("x", new StringScalar("X"))
+        ));
+        WriteReport report = new WriteReport();
+        YamlCodec.write(doc, false, report);
+
+        assertTrue(report.adjustments().stream().noneMatch(a -> a.code().equals("format.interleaving-lost")),
+            "unexpected interleaving-lost for a contiguous repeat: " + report);
+    }
 }

--- a/src/test/java/dev/omnist/conformance/ConformanceTest.java
+++ b/src/test/java/dev/omnist/conformance/ConformanceTest.java
@@ -34,7 +34,7 @@ class ConformanceTest {
         int[] results = Track2Runner.runTrack2(testSuitePath);
         assertNotNull(results);
         assertEquals(3, results.length);
-        assertEquals(153, results[0], "Track 2 should pass all 153 real JSON test vectors");
+        assertEquals(155, results[0], "Track 2 should pass all 155 real JSON test vectors");
         assertEquals(0, results[1], "Track 2 should have 0 failures");
         assertEquals(0, results[2], "Track 2 should have 0 skips");
     }


### PR DESCRIPTION
## Summary
- Implements omnist-spec Sec8.3.8 (D-3): three codec adjustments that were previously silent must now be reported as warning-severity diagnostics.
- XML read: `format.attribute-dropped` (path $.a) when an element's attributes are discarded, and `format.namespace-dropped` (path $.a.b) when a namespace-prefixed tag (`<ns:b>`) is read as its local name.
- JSON/YAML/TOML write: `format.interleaving-lost` (path $) when grouping same-label edges together actually loses cross-label interleaving order -- distinguished from a label merely repeating contiguously, which correctly does not fire.
- `Track2Runner` now captures and checks read-side diagnostics from `XmlCodec.read`, so a *successful* parse that still carries warning diagnostics is exercised by conformance, not just error-path diagnostics.
- Bumps `vendor/omnist-spec` to the commit adding the three new/updated conformance vectors.

## Test plan
- [x] `mvn verify` -- 596 tests pass, 0 failures, JaCoCo line/branch coverage gate met.
- [x] `./run-conformance` -- 184/184 pass, 0 fail, 0 skip, including the three new/updated D-3 vectors in `test-suite/formats-xml/xml.json` and `test-suite/formats-json/json.json`.
- [x] Unit tests added per codec (Json/Toml/Xml/Yaml) covering each new diagnostic plus a negative case: a contiguous repeat of the same label does NOT fire `format.interleaving-lost`.
- [x] XML-specific negative cases: a plain element with no attributes/prefixes emits no D-3 diagnostics; a bare default `xmlns` attribute and an `xmlns:ns` declaration attribute are not themselves reported as `format.attribute-dropped`.

Closes #84.
