### PR TITLE
Reject empty-string and bracket-containing field labels

### DIFF
--- a/src/main/java/dev/omnist/schema/OsdReader.java
+++ b/src/main/java/dev/omnist/schema/OsdReader.java
@@ -136,6 +136,13 @@ public class OsdReader {
             consumeToken(); // consume field label string
             String label = labelTok.text();
 
+            if (label.isEmpty()) {
+                throw new OsdParseException(labelTok.line(), labelTok.col(), "schema.empty-label", recordName, "Field label cannot be the empty string");
+            }
+            if (label.indexOf('[') >= 0 || label.indexOf(']') >= 0) {
+                throw new OsdParseException(labelTok.line(), labelTok.col(), "schema.bracket-in-label", recordName, "Field label cannot contain '[' or ']': '" + label + "'");
+            }
+
             if (!seenLabels.add(label)) {
                 throw new OsdParseException(labelTok.line(), labelTok.col(), "schema.duplicate-field", recordName, "Duplicate field label '" + label + "' in record '" + recordName + "'");
             }

--- a/src/test/java/dev/omnist/conformance/ConformanceTest.java
+++ b/src/test/java/dev/omnist/conformance/ConformanceTest.java
@@ -40,8 +40,8 @@ class ConformanceTest {
         // all 17 new conformance vectors for that batch at once, but the fixes land one PR
         // at a time. 15 vectors fail until the last PR in the batch (#91) lands; restore
         // these to 172/0/0 there.
-        assertEquals(157, results[0], "Track 2 should pass 157 of 172 real JSON test vectors during the #87-95 batch");
-        assertEquals(15, results[1], "Track 2 should have 15 known failures pending #88-95");
+        assertEquals(160, results[0], "Track 2 should pass 160 of 172 real JSON test vectors during the #87-95 batch");
+        assertEquals(12, results[1], "Track 2 should have 12 known failures pending #88-91, #93, #94");
         assertEquals(0, results[2], "Track 2 should have 0 skips");
     }
 

--- a/src/test/java/dev/omnist/schema/OsdReaderTest.java
+++ b/src/test/java/dev/omnist/schema/OsdReaderTest.java
@@ -166,6 +166,22 @@ class OsdReaderTest {
             () -> OsdReader.read("record R { \"a\" [0,0]: string } root R"));
         assertEquals("schema.invalid-cardinality", zeroZero.getCode());
 
+        // Empty-string field labels are rejected (issue #92)
+        OsdParseException emptyLabel = assertThrows(OsdParseException.class,
+            () -> OsdReader.read("record R { \"\": string } root R"));
+        assertEquals("schema.empty-label", emptyLabel.getCode());
+        assertEquals("R", emptyLabel.getPath());
+
+        // Brackets in field labels are rejected (issue #95)
+        OsdParseException bracketLabel = assertThrows(OsdParseException.class,
+            () -> OsdReader.read("record R { \"a[1]\": string } root R"));
+        assertEquals("schema.bracket-in-label", bracketLabel.getCode());
+        assertEquals("R", bracketLabel.getPath());
+
+        OsdParseException closingBracketOnly = assertThrows(OsdParseException.class,
+            () -> OsdReader.read("record R { \"total]\": string } root R"));
+        assertEquals("schema.bracket-in-label", closingBracketOnly.getCode());
+
 
         // [1.5] decimal bound
         assertThrows(OsdParseException.class, () -> OsdReader.read("record R { \"a\" [1.5]: string } root R"));


### PR DESCRIPTION
Per omnist-spec section 5.4, a schema field label MUST NOT be the empty string, and MUST NOT contain `[` or `]`.

## Changes
- `schema.empty-label`: an empty-string field label (`"": string`) names nothing a caller could ever reference. Path = enclosing record (same convention `schema.unquoted-label` already uses).
- `schema.bracket-in-label`: a label containing `[`/`]` collides with section 3.6.1's `validate()` path convention, which appends `[i]` to a repeated label's second-and-later occurrences -- a repeatable field `"a"` and a separately declared field literally named `"a[1]"` can otherwise produce the identical diagnostic path (`$.a[1]`) for two genuinely different problems.

Both checks land in `OsdReader`'s field-label parsing, right after the label string is extracted.

## Conformance
`osd-grammar/labels/empty-label-is-rejected`, `osd-grammar/labels/bracket-in-label-is-rejected`, and `osd-grammar/labels/closing-bracket-alone-in-label-is-rejected` all pass.

Part of the #87-95 batch (see #96); 12 of the 17 new conformance vectors for that batch remain pending in the next PRs, tracked via `ConformanceTest`'s counts (160/12/0 of 172).

`mvn clean test`: 596 tests, 0 failures, all coverage gates met.

Closes #92
Closes #95
