### PR TITLE
OML tokenizer: reject leading zeros, add DATE/TIME/DATETIME range validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,8 +199,18 @@
                                                  run's random inputs happen to hit can legitimately shift by a
                                                  branch or two run to run. A CI run at exactly 0.998 failed on
                                                  real, non-regressive variance (0.997 measured) shortly after this
-                                                 gate was first set at 0.998; this margin is the fix. -->
-                                            <minimum>0.995</minimum>
+                                                 gate was first set at 0.998; this margin is the fix.
+
+                                                 Updated 2026-08-30 (#94): fixing OmlLexer's DATETIME rule to
+                                                 throw directly on an out-of-range calendar/clock/tz-offset value
+                                                 (instead of silently falling through) made the DATE rule's own
+                                                 isDateTimeLookahead=true branch permanently unreachable too,
+                                                 that fall-through was the only way to reach it. Confirmed-
+                                                 unreachable comment left at the call site (OmlLexer's Rule 4),
+                                                 same treatment as the LINE gate's own dead-code lines. Re-
+                                                 measured at 99.4% with the new branch count; gate lowered just
+                                                 below that. -->
+                                            <minimum>0.993</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/src/main/java/dev/omnist/oml/OmlLexer.java
+++ b/src/main/java/dev/omnist/oml/OmlLexer.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.time.DateTimeException;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -201,10 +202,32 @@ public class OmlLexer {
                 DateTimeValue dtVal = parseDateTimeValue(text);
                 advance(text.length());
                 return new Token(TokenType.DATETIME, text, dtVal, startLine, startCol);
-            } catch (DateTimeParseException ignored) {}
+            } catch (DateTimeException e) {
+                // Syntactically shaped like a DATETIME but semantically invalid (out-of-range
+                // calendar/clock/tz-offset field, omnist-spec section 4.2.4, issue #94) --
+                // a definitive parse error at this token's position, not a signal to fall
+                // through and try other token rules.
+                int tIndex = text.indexOf('T');
+                String datePart = tIndex >= 0 ? text.substring(0, tIndex) : text;
+                if (!isValidDatePart(datePart)) {
+                    throw error("parse.invalid-date", "Invalid date in DATETIME literal: '" + text + "'", startLine, startCol);
+                }
+                throw error("parse.invalid-time", "Invalid time in DATETIME literal: '" + text + "'", startLine, startCol);
+            }
         }
 
-        // Rule 4: DATE (only when not followed by T plus a TIME-shaped lookahead)
+        // Rule 4: DATE (only when not followed by T plus a TIME-shaped lookahead).
+        //
+        // Confirmed-unreachable as of issue #94: DATETIME_PATTERN is structurally DATE_PATTERN
+        // + "T" + TIME_PATTERN, so whenever this lookahead's own condition (DATE_PATTERN
+        // matches here, followed by 'T', followed by a TIME_PATTERN match) is true, Rule 3's
+        // dtMatcher must also match at this same position -- and Rule 3 now always either
+        // returns a token or throws directly (it no longer silently falls through on an
+        // out-of-range DATETIME, per #94's fix above), so control can never reach this
+        // isDateTimeLookahead=true branch anymore. Kept as defensive belt-and-suspenders code
+        // in case DATE_PATTERN/TIME_PATTERN/DATETIME_PATTERN's structural relationship ever
+        // drifts apart; same documented-in-place convention as the LINE-gate's other
+        // confirmed-unreachable lines (see pom.xml's jacoco-maven-plugin check rule comment).
         if (dateMatcher.reset(source).region(pos, source.length()).lookingAt()) {
             String dateText = dateMatcher.group();
             int dateLen = dateText.length();
@@ -222,7 +245,12 @@ public class OmlLexer {
                     LocalDate dVal = LocalDate.parse(dateText);
                     advance(dateLen);
                     return new Token(TokenType.DATE, dateText, dVal, startLine, startCol);
-                } catch (DateTimeParseException ignored) {}
+                } catch (DateTimeException e) {
+                    // Syntactically shaped like a DATE but semantically invalid (out-of-range
+                    // month/day, non-leap Feb 29, omnist-spec section 4.2.4, issue #94) --
+                    // definitive parse error, not a fall-through signal.
+                    throw error("parse.invalid-date", "Invalid date: '" + dateText + "'", startLine, startCol);
+                }
             }
         }
 
@@ -233,12 +261,23 @@ public class OmlLexer {
                 TimeValue tVal = parseTimeValue(text);
                 advance(text.length());
                 return new Token(TokenType.TIME, text, tVal, startLine, startCol);
-            } catch (DateTimeParseException ignored) {}
+            } catch (DateTimeException e) {
+                // Syntactically shaped like a TIME but semantically invalid -- either the
+                // clock portion (hour/minute/second out of range, leap second) or the
+                // tz-offset (omnist-spec section 4.2.4, issue #94: tz-offset MUST share
+                // TIME's own hour/minute range check, not a separate looser one -- this
+                // shared catch is exactly that). Definitive parse error, not a fall-through
+                // signal.
+                throw error("parse.invalid-time", "Invalid time: '" + text + "'", startLine, startCol);
+            }
         }
 
         // Rule 6: NUMBER (decimal or exponent form)
         if (numMatcher.reset(source).region(pos, source.length()).lookingAt()) {
             String text = numMatcher.group();
+            if (hasLeadingZero(integerPartOf(text))) {
+                throw error("parse.leading-zero", "Leading zero not allowed in numeric literal: '" + text + "'", startLine, startCol);
+            }
             try {
                 double d = Double.parseDouble(text);
                 advance(text.length());
@@ -268,6 +307,9 @@ public class OmlLexer {
         // Rule 8: INTEGER (maxIntegerDigits limit enforced here)
         if (intMatcher.reset(source).region(pos, source.length()).lookingAt()) {
             String text = intMatcher.group();
+            if (hasLeadingZero(integerPartOf(text))) {
+                throw error("parse.leading-zero", "Leading zero not allowed in numeric literal: '" + text + "'", startLine, startCol);
+            }
             int digits = text.startsWith("-") ? text.length() - 1 : text.length();
             if (digits > limits.maxIntegerDigits()) {
                 throw error("document.limit.int-digits", "Integer literal digit count (" + digits + ") exceeds maximum limit of " + limits.maxIntegerDigits(), startLine, startCol);
@@ -294,6 +336,36 @@ public class OmlLexer {
         }
 
         throw error("parse.unexpected-token", "Unexpected character: '" + c + "'", startLine, startCol);
+    }
+
+    /**
+     * Extracts the integer part of a numeric literal's text (the digit run before any
+     * '.' or exponent marker), stripping a leading '-' sign. Used by the leading-zero
+     * check (omnist-spec section 4.2.3, issue #93): {@code int-part = "0" / (nonzero
+     * digit, then any digits)}.
+     */
+    private static String integerPartOf(String text) {
+        int start = text.startsWith("-") ? 1 : 0;
+        int end = start;
+        while (end < text.length() && Character.isDigit(text.charAt(end))) {
+            end++;
+        }
+        return text.substring(start, end);
+    }
+
+    /** True if {@code digits} is more than one character and starts with '0'. */
+    private static boolean hasLeadingZero(String digits) {
+        return digits.length() > 1 && digits.charAt(0) == '0';
+    }
+
+    /** True if {@code datePart} (the "YYYY-MM-DD" portion of a DATETIME) is a valid calendar date. */
+    private static boolean isValidDatePart(String datePart) {
+        try {
+            LocalDate.parse(datePart);
+            return true;
+        } catch (DateTimeException e) {
+            return false;
+        }
     }
 
     private boolean isReservedFloatWord(String target, int offset) {

--- a/src/test/java/dev/omnist/conformance/ConformanceTest.java
+++ b/src/test/java/dev/omnist/conformance/ConformanceTest.java
@@ -40,8 +40,8 @@ class ConformanceTest {
         // all 17 new conformance vectors for that batch at once, but the fixes land one PR
         // at a time. 15 vectors fail until the last PR in the batch (#91) lands; restore
         // these to 172/0/0 there.
-        assertEquals(160, results[0], "Track 2 should pass 160 of 172 real JSON test vectors during the #87-95 batch");
-        assertEquals(12, results[1], "Track 2 should have 12 known failures pending #88-91, #93, #94");
+        assertEquals(167, results[0], "Track 2 should pass 167 of 172 real JSON test vectors during the #87-95 batch");
+        assertEquals(5, results[1], "Track 2 should have 5 known failures pending #88-90 (fail-dont-invent) and #91 (XML CR escaping)");
         assertEquals(0, results[2], "Track 2 should have 0 skips");
     }
 

--- a/src/test/java/dev/omnist/oml/OmlLexerTest.java
+++ b/src/test/java/dev/omnist/oml/OmlLexerTest.java
@@ -141,4 +141,76 @@ class OmlLexerTest {
         List<Token> offset = tokenize("10:00:00+05:30");
         assertEquals(TokenType.TIME, offset.get(0).type());
     }
+
+    @Test
+    @DisplayName("Leading zero in an INTEGER's integer part is rejected (issue #93)")
+    void testLeadingZeroIntegerIsAnError() {
+        OmlParseException ex = assertThrows(OmlParseException.class, () -> tokenize("n: 01"));
+        assertEquals("parse.leading-zero", ex.getCode());
+    }
+
+    @Test
+    @DisplayName("Leading zero in a NUMBER's integer part is rejected even before the decimal point (issue #93)")
+    void testLeadingZeroInDecimalIsAnError() {
+        OmlParseException ex = assertThrows(OmlParseException.class, () -> tokenize("n: 00.5"));
+        assertEquals("parse.leading-zero", ex.getCode());
+    }
+
+    @Test
+    @DisplayName("A bare 0, -0, 0.5, and -12 are all still valid (no leading-zero false positive)")
+    void testSingleZeroAndNegativeFormsAreValid() {
+        assertEquals(TokenType.INTEGER, tokenize("0").get(0).type());
+        assertEquals(TokenType.INTEGER, tokenize("-0").get(0).type());
+        assertEquals(TokenType.NUMBER, tokenize("0.5").get(0).type());
+        assertEquals(TokenType.INTEGER, tokenize("-12").get(0).type());
+    }
+
+    @Test
+    @DisplayName("DATE with an out-of-range month is a definitive parse.invalid-date error (issue #94)")
+    void testDateOutOfRangeMonthIsAnError() {
+        OmlParseException ex = assertThrows(OmlParseException.class, () -> tokenize("n: 2024-13-01"));
+        assertEquals("parse.invalid-date", ex.getCode());
+    }
+
+    @Test
+    @DisplayName("DATE with a day invalid for its month is a parse.invalid-date error (issue #94)")
+    void testDateDayInvalidForMonthIsAnError() {
+        OmlParseException ex = assertThrows(OmlParseException.class, () -> tokenize("n: 2024-02-30"));
+        assertEquals("parse.invalid-date", ex.getCode());
+    }
+
+    @Test
+    @DisplayName("February 29 in a non-leap year is a parse.invalid-date error (issue #94)")
+    void testFebruary29NonLeapYearIsAnError() {
+        OmlParseException ex = assertThrows(OmlParseException.class, () -> tokenize("n: 1900-02-29"));
+        assertEquals("parse.invalid-date", ex.getCode());
+    }
+
+    @Test
+    @DisplayName("February 29 in a leap year is valid (issue #94 happy path)")
+    void testFebruary29LeapYearIsValid() {
+        List<Token> tokens = tokenize("2000-02-29");
+        assertEquals(TokenType.DATE, tokens.get(0).type());
+    }
+
+    @Test
+    @DisplayName("A leap second (23:59:60) is a parse.invalid-time error (issue #94)")
+    void testLeapSecondIsAnError() {
+        OmlParseException ex = assertThrows(OmlParseException.class, () -> tokenize("n: 2024-01-01T23:59:60"));
+        assertEquals("parse.invalid-time", ex.getCode());
+    }
+
+    @Test
+    @DisplayName("A tz-offset minute out of range (+00:60) is a parse.invalid-time error, sharing TIME's own range check (issue #94)")
+    void testTzOffsetMinuteOutOfRangeIsAnError() {
+        OmlParseException ex = assertThrows(OmlParseException.class, () -> tokenize("n: 2024-01-01T10:30+00:60"));
+        assertEquals("parse.invalid-time", ex.getCode());
+    }
+
+    @Test
+    @DisplayName("A tz-offset within range is valid (issue #94 happy path)")
+    void testTzOffsetWithinRangeIsValid() {
+        List<Token> tokens = tokenize("2024-01-01T10:30+01:00");
+        assertEquals(TokenType.DATETIME, tokens.get(0).type());
+    }
 }


### PR DESCRIPTION
Per omnist-spec section 4.2.3/4.2.4 (newly normative), the OML tokenizer's NUMBER/INTEGER lexical grammar forbids leading zeros, and DATE/TIME/DATETIME/tz-offset get real calendar/clock range validation.

## Changes
- `parse.leading-zero`: reject a leading zero in the integer part of a numeric literal (`int-part = "0" / (nonzero digit, then any digits)`), matching JSON/TOML's own convention. `0`, `-0`, `0.5`, `-12` remain valid.
- `parse.invalid-date` / `parse.invalid-time`: month 01-12, day valid for month/year (real leap-year check), hour 00-23, minute 00-59, second 00-59 (no leap second). `java.time` already enforces all of this via `LocalDate`/`LocalTime`/`ZoneOffset` -- the actual bug was `OmlLexer` silently swallowing the resulting exception and falling through to try other token rules, producing a `parse.trailing-content` error at the wrong position instead of a real diagnostic at the literal itself. tz-offset explicitly shares TIME's own catch (the real bug fixed: `+00:60` used to be silently accepted and mis-normalized to a 1-hour offset).

`OmlLexer`'s own `isDateTimeLookahead=true` branch (Rule 4's DATE-vs-DATETIME lookahead) becomes permanently unreachable as a direct consequence (Rule 3 now always returns or throws directly instead of silently falling through, which was the only way to reach it) -- documented in place; BRANCH coverage gate in `pom.xml` adjusted (0.995 -> 0.993).

## Conformance
All 7 new `oml-grammar/numbers` and `oml-grammar/temporals` vectors pass (plus 2 happy-path vectors that already passed incidentally).

Part of the #87-95 batch (see #96); 5 of the 17 new conformance vectors remain pending (issues #88-91), tracked via `ConformanceTest`'s counts (167/5/0 of 172).

`mvn clean test`: 596 tests, 0 failures, all coverage gates met.

Closes #93
Closes #94
