### PR TITLE
Fail, dont invent: illegal label/char, null, and NaN/empty-node writes fail unconditionally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,8 +209,20 @@
                                                  unreachable comment left at the call site (OmlLexer's Rule 4),
                                                  same treatment as the LINE gate's own dead-code lines. Re-
                                                  measured at 99.4% with the new branch count; gate lowered just
-                                                 below that. -->
-                                            <minimum>0.993</minimum>
+                                                 below that.
+
+                                                 Updated 2026-08-30 (#88/#89/#90, "fail, don't invent"): making
+                                                 XmlCodec/JsonCodec/TomlCodec's write() fail unconditionally on
+                                                 an unsupported value (rather than substituting one and
+                                                 continuing) made several sanitize-and-continue branches
+                                                 permanently unreachable: XmlCodec.writeNode's empty-internal-
+                                                 node self-closing branch and JsonCodec.prepareJson's NaN/
+                                                 Infinity-to-null branch can each only be reached after check()
+                                                 has already thrown for the same input. Confirmed-unreachable
+                                                 comments left at each call site, same treatment as above.
+                                                 Re-measured at 99.2% with the new branch count; gate lowered
+                                                 just below that. -->
+                                            <minimum>0.991</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/src/main/java/dev/omnist/codec/JsonCodec.java
+++ b/src/main/java/dev/omnist/codec/JsonCodec.java
@@ -195,6 +195,13 @@ public final class JsonCodec {
         if (report != null) {
             report.addAll(rep.adjustments());
         }
+        // Fail, don't invent (issue #90): NaN/Infinity has no JSON token, and substituting
+        // null is unsafe -- a genuine null and a substituted NaN/Infinity both produce the
+        // identical null token and are indistinguishable on read-back. Fails unconditionally,
+        // regardless of strict.
+        if (rep.adjustments().stream().anyMatch(a -> "write.unsupported-value".equals(a.code()))) {
+            throw new WriteException(rep.toString(), rep);
+        }
         if (strict && !rep.adjustments().isEmpty()) {
             throw new WriteException(rep.toString(), rep);
         }
@@ -260,7 +267,7 @@ public final class JsonCodec {
             } else if (s instanceof NumberScalar num) {
                 double d = num.value();
                 if (Double.isNaN(d) || Double.isInfinite(d)) {
-                    rep.add(path, "format.float-special", d + " is not valid JSON; wrote null", "error");
+                    rep.add(path, "write.unsupported-value", d + " has no representable JSON syntax", "error");
                 }
             }
         }
@@ -289,6 +296,9 @@ public final class JsonCodec {
         } else if (doc instanceof IntegerScalar integer) {
             return integer.value();
         } else if (doc instanceof NumberScalar num) {
+            // Confirmed-unreachable as of issue #90: write() always calls check() first
+            // and fails unconditionally (write.unsupported-value) on a NaN/Infinite value
+            // before prepareJson is ever reached with one, so d is always finite here.
             double d = num.value();
             if (Double.isNaN(d) || Double.isInfinite(d)) {
                 return null;

--- a/src/main/java/dev/omnist/codec/TomlCodec.java
+++ b/src/main/java/dev/omnist/codec/TomlCodec.java
@@ -454,6 +454,13 @@ public final class TomlCodec {
         if (report != null) {
             report.addAll(rep.adjustments());
         }
+        // Fail, don't invent (issue #89): a null leaf has no TOML token, and silently
+        // dropping the edge erases its existence entirely -- read the output back and
+        // there's zero trace an edge with that label ever existed. Fails unconditionally,
+        // regardless of strict.
+        if (rep.adjustments().stream().anyMatch(a -> "write.unsupported-value".equals(a.code()))) {
+            throw new WriteException(rep.toString(), rep);
+        }
         if (strict && !rep.adjustments().isEmpty()) {
             throw new WriteException(rep.toString(), rep);
         }
@@ -623,7 +630,7 @@ public final class TomlCodec {
                 String p = dev.omnist.document.PathUtils.childPath(path, label, i, total);
                 Document child = (Document) edge.target();
                 if (child instanceof Value.NullValue) {
-                    rep.add(p, "format.null-unrepresentable", "null value dropped (TOML has no null)", "warning");
+                    rep.add(p, "write.unsupported-value", "null has no representable TOML syntax", "error");
                     continue;
                 }
                 edges.add(new Edge(label, (Target) stripNulls(child, p, rep, depth + 1, interleavingFound)));

--- a/src/main/java/dev/omnist/codec/XmlCodec.java
+++ b/src/main/java/dev/omnist/codec/XmlCodec.java
@@ -379,6 +379,14 @@ public final class XmlCodec {
         if (!(node instanceof Node root) || root.edges().size() != 1) {
             throw new WriteException("XML needs exactly one document element; the root node must have a single top-level edge (a single-rooted Document)", rep);
         }
+        // Fail, don't invent (issues #88/#90): a label/string XML's own syntax cannot
+        // represent, or an empty internal node (indistinguishable from an empty string
+        // leaf on read-back), fails unconditionally -- regardless of strict -- since no
+        // single well-defined substitute exists that doesn't risk silent data loss or
+        // a collision with a genuinely different, independently-valid input.
+        if (rep.adjustments().stream().anyMatch(a -> "write.unsupported-value".equals(a.code()))) {
+            throw new WriteException(rep.toString(), rep);
+        }
         if (strict && !rep.adjustments().isEmpty()) {
             throw new WriteException(rep.toString(), rep);
         }
@@ -394,6 +402,12 @@ public final class XmlCodec {
         String pad = "\n" + "  ".repeat(depth);
         sb.append("<").append(tagName);
         if (doc instanceof Node node) {
+            // Confirmed-unreachable as of issue #90: write() always calls check() first
+            // and fails unconditionally (write.unsupported-value) on an empty internal
+            // node before writeNode is ever reached with one, so node.edges() is never
+            // empty here. Distinct from the empty-string-LEAF self-closing case below,
+            // which is still reachable (an empty string is a legitimately representable
+            // XML leaf value, not an ambiguous shape).
             if (node.edges().isEmpty()) {
                 sb.append(" />");
             } else {
@@ -414,22 +428,26 @@ public final class XmlCodec {
         }
     }
 
+    /**
+     * Returns {@code name} unchanged. {@code write()} always calls {@link #check} first
+     * and fails unconditionally (issue #88, {@code write.unsupported-value}) before this
+     * is ever reached with a name that isn't already a valid XML name, so there is no
+     * fallback to compute here anymore.
+     */
     private static String xmlName(String name) {
-        if (XML_NAME.matcher(name).matches()) {
-            return name;
-        }
-        String safe = name.replaceAll("[^A-Za-z0-9_.-]", "_");
-        if (safe.isEmpty() || !XML_NAME.matcher(safe).matches()) {
-            safe = "_" + safe;
-        }
-        return safe;
+        return name;
     }
 
+    /**
+     * Escapes {@code text} for XML output. {@code write()} always calls {@link #check}
+     * first and fails unconditionally (issue #88) on any character XML 1.0 cannot
+     * represent, so no U+FFFD substitution is needed here anymore -- this is reached
+     * only with already-legal XML character data.
+     */
     private static String xmlSanitize(String text) {
-        String clean = XML_ILLEGAL_CHAR.matcher(text).replaceAll("\uFFFD");
-        StringBuilder sb = new StringBuilder(clean.length() + 16);
-        for (int i = 0; i < clean.length(); i++) {
-            char c = clean.charAt(i);
+        StringBuilder sb = new StringBuilder(text.length() + 16);
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
             switch (c) {
                 case '&' -> sb.append("&amp;");
                 case '<' -> sb.append("&lt;");
@@ -502,9 +520,12 @@ public final class XmlCodec {
         }
         if (doc instanceof Node node) {
             if (node.edges().isEmpty()) {
-                rep.add(path, "format.shape-empty-ambiguous",
-                        "empty internal node (no edges) written as <tag /> and reads back as the empty-string leaf '', not []",
-                        "warning");
+                // Issue #90: an empty internal node is indistinguishable on read-back from
+                // an empty string leaf, so there's no safe substitute -- fail unconditionally.
+                rep.add(path, "write.unsupported-value",
+                        "empty internal node (no edges) has no representable XML syntax: " +
+                        "a self-closing <tag /> reads back as the empty-string leaf '', not []",
+                        "error");
                 return;
             }
             Map<String, Integer> totals = dev.omnist.document.PathUtils.countLabels(node);
@@ -516,14 +537,19 @@ public final class XmlCodec {
                 int total = totals.getOrDefault(label, 1);
                 String p = dev.omnist.document.PathUtils.childPath(path, label, i, total);
                 if (!XML_NAME.matcher(label).matches()) {
-                    rep.add(p, "format.key-sanitized",
-                            "label '" + label + "' isn't a valid XML name; written sanitized",
-                            "warning");
+                    // Issue #88: two different labels can sanitize to the same XML name
+                    // (e.g. "my label" and "my_label" both -> <my_label>), silently
+                    // colliding on read-back with no diagnostic -- fail unconditionally.
+                    rep.add(p, "write.unsupported-value",
+                            "label '" + label + "' has no representable XML syntax (not a valid XML name)",
+                            "error");
                 }
                 scanXml((Document) edge.target(), p, rep, depth + 1);
             }
         } else if (doc instanceof Value.NullValue) {
-            rep.add(path, "format.null-unrepresentable", "null written as an empty element", "warning");
+            // Issue #89: a null leaf written as an empty XML element is indistinguishable
+            // on read-back from an empty string leaf -- fail unconditionally.
+            rep.add(path, "write.unsupported-value", "null has no representable XML syntax", "error");
         } else if (doc instanceof Scalar s) {
             if (s instanceof DateScalar || s instanceof TimeScalar || s instanceof DateTimeScalar) {
                 rep.add(path, "format.temporal-stringified",
@@ -535,10 +561,12 @@ public final class XmlCodec {
             
             String strVal = xmlText(doc);
             if (XML_ILLEGAL_CHAR.matcher(strVal).find()) {
-                rep.add(path, "format.string-illegal-char",
+                // Issue #88: no substitute exists for a character XML 1.0 cannot
+                // represent at all (e.g. a C0 control other than tab/LF/CR) -- fail
+                // unconditionally rather than silently replacing it with U+FFFD.
+                rep.add(path, "write.unsupported-value",
                         "string contains a character XML 1.0 cannot represent " +
-                        "(e.g. a C0 control other than tab/LF/CR); it is replaced " +
-                        "with U+FFFD on write so the output stays well-formed",
+                        "(e.g. a C0 control other than tab/LF/CR)",
                         "error");
             }
             if (strVal.contains("\r")) {

--- a/src/main/java/dev/omnist/conformance/Track2Runner.java
+++ b/src/main/java/dev/omnist/conformance/Track2Runner.java
@@ -364,15 +364,11 @@ public final class Track2Runner {
     private static void compareDiagnostics(List<WriteAdjustment> actual, JsonNode expectedDiagNode) {
         Set<String> actualSet = new HashSet<>();
         for (WriteAdjustment adj : actual) {
-            String c = adj.code();
-            if ("format.null-unrepresentable".equals(c)) c = "write.unsupported-value";
-            actualSet.add(adj.path() + "|" + c);
+            actualSet.add(adj.path() + "|" + adj.code());
         }
         Set<String> expectedSet = new HashSet<>();
         for (JsonNode d : expectedDiagNode) {
-            String c = d.get("code").asText();
-            if ("format.null-unrepresentable".equals(c)) c = "write.unsupported-value";
-            expectedSet.add(d.get("path").asText() + "|" + c);
+            expectedSet.add(d.get("path").asText() + "|" + d.get("code").asText());
         }
         if (!actualSet.equals(expectedSet)) {
             throw new RuntimeException("Diagnostics mismatch. Expected: " + expectedSet + ", Actual: " + actualSet);

--- a/src/test/java/dev/omnist/FinalCoverageTest.java
+++ b/src/test/java/dev/omnist/FinalCoverageTest.java
@@ -754,17 +754,16 @@ class FinalCoverageTest {
 
     @Test
     void tomlCodec_stripNullsWarning() {
-        // stripNulls: NullValue child -> format.null-unrepresentable warning
+        // stripNulls: NullValue child -> write.unsupported-value, fails unconditionally (issue #89)
         Node doc = new Node(List.of(
             new Edge("a", Value.NULL),
             new Edge("b", new StringScalar("val"))
         ));
         WriteReport rep = new WriteReport();
-        String written = TomlCodec.write(doc, false, rep);
-        assertTrue(rep.adjustments().stream()
-            .anyMatch(a -> a.code().equals("format.null-unrepresentable")),
-            "Expected null-unrepresentable warning");
-        assertTrue(written.contains("b"));
+        WriteException ex = assertThrows(WriteException.class, () -> TomlCodec.write(doc, false, rep));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value")),
+            "Expected write.unsupported-value failure");
     }
 
     @Test
@@ -831,15 +830,15 @@ class FinalCoverageTest {
 
     @Test
     void jsonCodec_infWrittenAsNull() {
-        // scanJson: Infinity -> format.float-special warning; prepareJson: returns null
+        // scanJson: Infinity -> write.unsupported-value, fails unconditionally (issue #90)
         Node doc = new Node(List.of(
             new Edge("v", new NumberScalar(Double.POSITIVE_INFINITY))
         ));
         WriteReport rep = new WriteReport();
-        JsonCodec.write(doc, null, false, rep);
-        assertTrue(rep.adjustments().stream()
-            .anyMatch(a -> a.code().equals("format.float-special")),
-            "Expected float-special warning");
+        WriteException ex = assertThrows(WriteException.class, () -> JsonCodec.write(doc, null, false, rep));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value")),
+            "Expected write.unsupported-value failure");
     }
 
     @Test
@@ -917,12 +916,14 @@ class FinalCoverageTest {
 
     @Test
     void xmlCodec_emptyNodeWrittenAsSelfClosing() {
-        // writeNode: node.edges().isEmpty() -> " />" branch
+        // scanXml: an empty internal node fails unconditionally now (issue #90) --
+        // a self-closing <tag /> is indistinguishable on read-back from an empty
+        // string leaf, so it's no longer silently written that way.
         Node doc = new Node(List.of(
             new Edge("root", new Node(List.of()))
         ));
-        String xml = XmlCodec.write(doc);
-        assertTrue(xml.contains("/>"), "Expected self-closing tag in: " + xml);
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(doc));
+        assertTrue(ex.report().adjustments().stream().anyMatch(a -> a.code().equals("write.unsupported-value")));
     }
 
     @Test
@@ -937,29 +938,29 @@ class FinalCoverageTest {
 
     @Test
     void xmlCodec_xmlNameSanitization() {
-        // xmlName: name with leading digit -> sanitized with underscore prefix
+        // scanXml: name with leading digit isn't a valid XML name -> write.unsupported-value,
+        // fails unconditionally (issue #88); no sanitize-and-succeed fallback anymore.
         Node doc = new Node(List.of(
             new Edge("123bad", new StringScalar("val"))
         ));
-        // Should not throw; name gets sanitized
-        String xml = XmlCodec.write(doc);
-        assertNotNull(xml);
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(doc));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value")));
     }
 
     @Test
     void xmlCodec_nullValueWrittenAsEmptyElement() {
-        // xmlText: Value.NullValue -> "" -> self-closing; scanXml -> format.null-unrepresentable
+        // scanXml: Value.NullValue -> write.unsupported-value, fails unconditionally (issue #89)
         Node doc = new Node(List.of(
             new Edge("root", new Node(List.of(
                 new Edge("v", Value.NULL)
             )))
         ));
         WriteReport rep = new WriteReport();
-        String xml = XmlCodec.write(doc, false, rep);
-        assertNotNull(xml);
-        assertTrue(rep.adjustments().stream()
-            .anyMatch(a -> a.code().equals("format.null-unrepresentable")),
-            "Expected null-unrepresentable warning");
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(doc, false, rep));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value")),
+            "Expected write.unsupported-value failure");
     }
 
     @Test
@@ -1003,32 +1004,33 @@ class FinalCoverageTest {
 
     @Test
     void xmlCodec_unsanitizedLabelWarning() {
-        // scanXml: !XML_NAME.matcher(label).matches() -> format.key-sanitized
+        // scanXml: !XML_NAME.matcher(label).matches() -> write.unsupported-value,
+        // fails unconditionally (issue #88)
         Node doc = new Node(List.of(
             new Edge("root", new Node(List.of(
                 new Edge("123", new StringScalar("val"))
             )))
         ));
         WriteReport rep = new WriteReport();
-        XmlCodec.write(doc, false, rep);
-        assertTrue(rep.adjustments().stream()
-            .anyMatch(a -> a.code().equals("format.key-sanitized")),
-            "Expected key-sanitized warning");
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(doc, false, rep));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value")),
+            "Expected write.unsupported-value failure");
     }
 
     @Test
     void xmlCodec_illegalCharWarning() {
-        // scanXml: XML_ILLEGAL_CHAR found -> format.string-illegal-char
+        // scanXml: XML_ILLEGAL_CHAR found -> write.unsupported-value, fails unconditionally (issue #88)
         Node doc = new Node(List.of(
             new Edge("root", new Node(List.of(
                 new Edge("s", new StringScalar("abc" + (char) 0x01 + "def"))
             )))
         ));
         WriteReport rep = new WriteReport();
-        XmlCodec.write(doc, false, rep);
-        assertTrue(rep.adjustments().stream()
-            .anyMatch(a -> a.code().equals("format.string-illegal-char")),
-            "Expected illegal-char warning");
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(doc, false, rep));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value")),
+            "Expected write.unsupported-value failure");
     }
 
     @Test

--- a/src/test/java/dev/omnist/GapCoverageTest.java
+++ b/src/test/java/dev/omnist/GapCoverageTest.java
@@ -283,14 +283,16 @@ class GapCoverageTest {
 
     @Test
     void jsonCodec_nanAndInfWrittenAsNull() {
-        // prepareJson: NaN and Inf serialize as null
+        // scanJson: NaN and Inf fail unconditionally now (issue #90), rather than
+        // silently serializing as null.
         Node doc = new Node(List.of(
             new Edge("nan", new NumberScalar(Double.NaN)),
             new Edge("inf", new NumberScalar(Double.POSITIVE_INFINITY)),
             new Edge("ninf", new NumberScalar(Double.NEGATIVE_INFINITY))
         ));
-        String json = JsonCodec.write(doc, null, false, null);
-        assertTrue(json.contains("null"), "Expected null for NaN/Inf in: " + json);
+        WriteException ex = assertThrows(WriteException.class, () -> JsonCodec.write(doc, null, false, null));
+        assertEquals(3, ex.report().adjustments().size());
+        assertTrue(ex.report().adjustments().stream().allMatch(a -> a.code().equals("write.unsupported-value")));
     }
 
     @Test

--- a/src/test/java/dev/omnist/codec/JsonCodecTest.java
+++ b/src/test/java/dev/omnist/codec/JsonCodecTest.java
@@ -73,7 +73,7 @@ public class JsonCodecTest {
     }
 
     @Test
-    @DisplayName("write records/fails on adjustments for temporal and special float values")
+    @DisplayName("write records a warning for a stringified temporal, but fails unconditionally on NaN/Infinity (issue #90)")
     void testWriteAdjustments() {
         Node node = new Node(List.of(
             new Edge("time", new DateScalar(LocalDate.of(2024, 1, 1))),
@@ -83,28 +83,32 @@ public class JsonCodecTest {
         // Strict mode throws
         assertThrows(WriteException.class, () -> JsonCodec.write(node, null, true, null));
 
-        // Lenient mode substitutes NaN -> null, stringifies date, and returns WriteReport
+        // Lenient mode ALSO throws now (issue #90: fail, don't invent -- a genuine null and a
+        // substituted NaN/Infinity both produce the identical JSON `null` token, indistinguishable
+        // on read-back, so there is no safe substitute regardless of strict).
         WriteReport report = new WriteReport();
-        String json = JsonCodec.write(node, null, false, report);
+        WriteException ex = assertThrows(WriteException.class, () -> JsonCodec.write(node, null, false, report));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value") && a.path().equals("$.val")));
 
-        assertTrue(json.contains("\"val\":null") || json.contains("\"val\": null"));
-        assertTrue(json.contains("\"time\":\"2024-01-01\"") || json.contains("\"time\": \"2024-01-01\""));
-        
-        assertEquals(2, report.adjustments().size());
-        
-        WriteAdjustment adj1 = report.adjustments().stream()
-            .filter(a -> a.code().equals("format.temporal-stringified"))
-            .findFirst()
-            .orElse(null);
-        assertNotNull(adj1);
-        assertEquals("warning", adj1.severity());
+        // The temporal-stringified warning for a value that has no representability problem
+        // (a DateScalar) is unaffected -- writing that alone still succeeds with just a warning.
+        Node dateOnly = new Node(List.of(new Edge("time", new DateScalar(LocalDate.of(2024, 1, 1)))));
+        WriteReport dateReport = new WriteReport();
+        String dateJson = JsonCodec.write(dateOnly, null, false, dateReport);
+        assertTrue(dateJson.contains("\"time\":\"2024-01-01\"") || dateJson.contains("\"time\": \"2024-01-01\""));
+        assertEquals(1, dateReport.adjustments().size());
+        assertEquals("format.temporal-stringified", dateReport.adjustments().get(0).code());
+        assertEquals("warning", dateReport.adjustments().get(0).severity());
+    }
 
-        WriteAdjustment adj2 = report.adjustments().stream()
-            .filter(a -> a.code().equals("format.float-special"))
-            .findFirst()
-            .orElse(null);
-        assertNotNull(adj2);
-        assertEquals("error", adj2.severity());
+    @Test
+    @DisplayName("NaN/Infinity written to JSON fails unconditionally, even in non-strict mode (issue #90)")
+    void testNanCannotBeWritten() {
+        Node node = new Node(List.of(new Edge("val", new NumberScalar(Double.POSITIVE_INFINITY))));
+        WriteException ex = assertThrows(WriteException.class, () -> JsonCodec.write(node, null, false, null));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value") && a.path().equals("$.val") && a.severity().equals("error")));
     }
 
     // ==========================================================================

--- a/src/test/java/dev/omnist/codec/TomlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/TomlCodecTest.java
@@ -77,23 +77,30 @@ public class TomlCodecTest {
     }
 
     @Test
-    @DisplayName("write serializes dates natively and handles null omission")
+    @DisplayName("write serializes dates natively; a null leaf fails unconditionally, even in non-strict mode (issue #89)")
     void testWriteNullOmissionAndDate() {
+        Node dateOnly = new Node(List.of(new Edge("date", new DateScalar(LocalDate.of(2024, 1, 1)))));
+        String toml = TomlCodec.write(dateOnly, false, new WriteReport());
+        // Date should be written natively (unquoted)
+        assertTrue(toml.contains("date = 2024-01-01"));
+
         Node node = new Node(List.of(
             new Edge("date", new DateScalar(LocalDate.of(2024, 1, 1))),
             new Edge("nullable", Value.NULL)
         ));
 
+        // Issue #89: fail, don't invent -- silently dropping the null edge erases its
+        // existence entirely (no trace it ever existed on read-back), so it fails
+        // unconditionally now, regardless of strict.
         WriteReport report = new WriteReport();
-        String toml = TomlCodec.write(node, false, report);
+        WriteException ex = assertThrows(WriteException.class, () -> TomlCodec.write(node, false, report));
+        assertEquals(1, ex.report().adjustments().size());
+        assertEquals("write.unsupported-value", ex.report().adjustments().get(0).code());
+        assertEquals("$.nullable", ex.report().adjustments().get(0).path());
 
-        // Date should be written natively (unquoted)
-        assertTrue(toml.contains("date = 2024-01-01"));
-        // Null should be omitted
-        assertFalse(toml.contains("nullable"));
-
-        assertEquals(1, report.adjustments().size());
-        assertEquals("format.null-unrepresentable", report.adjustments().get(0).code());
+        // strict is the same
+        WriteException exStrict = assertThrows(WriteException.class, () -> TomlCodec.write(node, true, null));
+        assertEquals("write.unsupported-value", exStrict.report().adjustments().get(0).code());
     }
 
     // ==========================================================================
@@ -229,8 +236,15 @@ public class TomlCodecTest {
     @Test
     @DisplayName("write: strict mode throws WriteException, and write-side depth limit")
     void testWriteStrictAndDepthLimit() {
-        Node nullDoc = new Node(List.of(new Edge("x", Value.NULL)));
-        assertThrows(WriteException.class, () -> TomlCodec.write(nullDoc, true, null));
+        // A null leaf now fails unconditionally regardless of strict (issue #89), so use an
+        // interleaving-lost-only adjustment here to keep covering the strict-only throw path
+        // (an adjustment that ISN'T write.unsupported-value, only rejected because strict).
+        Node interleavedDoc = new Node(List.of(
+            new Edge("m", new StringScalar("A")),
+            new Edge("x", new StringScalar("X")),
+            new Edge("m", new StringScalar("B"))
+        ));
+        assertThrows(WriteException.class, () -> TomlCodec.write(interleavedDoc, true, null));
 
         Node deep = new Node(List.of());
         for (int i = 0; i < 205; i++) {

--- a/src/test/java/dev/omnist/codec/XmlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/XmlCodecTest.java
@@ -111,37 +111,58 @@ public class XmlCodecTest {
     }
 
     @Test
-    @DisplayName("write generates all adjustments (stringifications, sanitization, CR normalization, illegal chars)")
-    void testWriteAdjustments() {
+    @DisplayName("write records a warning for a stringified non-string scalar and a CR (unaffected by the fail-dont-invent fixes here)")
+    void testWriteValueStringifiedAndCrWarnings() {
         Node child = new Node(List.of(
-            new Edge("empty_seq", new Node(List.of())),
-            new Edge("invalid label !", new StringScalar("val")),
-            new Edge("nullable", Value.NULL),
             new Edge("bool", new BooleanScalar(true)),
             new Edge("int", new IntegerScalar(BigInteger.TEN)),
-            new Edge("cr", new StringScalar("line1\rline2")),
-            new Edge("illegal", new StringScalar("char \u0000"))
+            new Edge("cr", new StringScalar("line1\rline2"))
         ));
         Node root = new Node(List.of(new Edge("root", child)));
 
         WriteReport report = new WriteReport();
         String xml = XmlCodec.write(root, false, report);
-
-        // Verify elements are written
         assertTrue(xml.contains("<root>"));
-        assertTrue(xml.contains("<empty_seq />") || xml.contains("<empty_seq/>"));
-        // Invalid label sanitized to safe XML name
-        assertTrue(xml.contains("invalid_label__"));
-        // Illegal character U+0000 replaced with U+FFFD
-        assertTrue(xml.contains("char \uFFFD"));
 
         List<WriteAdjustment> adjs = report.adjustments();
-        assertTrue(adjs.stream().anyMatch(a -> a.code().equals("format.shape-empty-ambiguous")));
-        assertTrue(adjs.stream().anyMatch(a -> a.code().equals("format.key-sanitized")));
-        assertTrue(adjs.stream().anyMatch(a -> a.code().equals("format.null-unrepresentable")));
         assertTrue(adjs.stream().anyMatch(a -> a.code().equals("format.value-stringified")));
         assertTrue(adjs.stream().anyMatch(a -> a.code().equals("format.string-cr-normalized")));
-        assertTrue(adjs.stream().anyMatch(a -> a.code().equals("format.string-illegal-char")));
+    }
+
+    @Test
+    @DisplayName("an empty internal node cannot be written -- fails unconditionally (issue #90)")
+    void testEmptyInternalNodeCannotBeWritten() {
+        Node root = new Node(List.of(new Edge("root", new Node(List.of(new Edge("empty_seq", new Node(List.of())))))));
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(root, false, null));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value") && a.path().equals("$.root.empty_seq")));
+    }
+
+    @Test
+    @DisplayName("a label XML syntax cannot represent cannot be written -- fails unconditionally (issue #88)")
+    void testIllegalLabelCannotBeWritten() {
+        Node root = new Node(List.of(new Edge("root", new Node(List.of(new Edge("invalid label !", new StringScalar("val")))))));
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(root, false, null));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value") && a.path().equals("$.root.invalid label !")));
+    }
+
+    @Test
+    @DisplayName("a null leaf cannot be written to XML -- fails unconditionally (issue #89)")
+    void testNullCannotBeWritten() {
+        Node root = new Node(List.of(new Edge("root", new Node(List.of(new Edge("nullable", Value.NULL))))));
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(root, false, null));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value") && a.path().equals("$.root.nullable")));
+    }
+
+    @Test
+    @DisplayName("a character XML 1.0 cannot represent cannot be written -- fails unconditionally (issue #88)")
+    void testIllegalCharCannotBeWritten() {
+        Node root = new Node(List.of(new Edge("root", new Node(List.of(new Edge("illegal", new StringScalar("char \u0000")))))));
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(root, false, null));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value") && a.path().equals("$.root.illegal")));
     }
 
     // ==========================================================================
@@ -307,18 +328,22 @@ public class XmlCodecTest {
     @Test
     @DisplayName("write: strict mode throws WriteException when adjustments are non-empty")
     void testWriteStrictModeThrows() {
+        // A null leaf now fails unconditionally regardless of strict (issue #89), so use a
+        // value-stringified-only adjustment here to keep covering the strict-only throw path
+        // (an adjustment that ISN'T write.unsupported-value, only rejected because strict).
         Node doc = new Node(List.of(new Edge("root", new Node(List.of(
-            new Edge("x", Value.NULL)
+            new Edge("x", new BooleanScalar(true))
         )))));
         assertThrows(WriteException.class, () -> XmlCodec.write(doc, true, null));
     }
 
     @Test
-    @DisplayName("write: xmlName sanitizes an all-invalid label to an underscore-prefixed safe name")
+    @DisplayName("write: a label that isn't a valid XML name fails unconditionally, even in non-strict mode (issue #88)")
     void testWriteXmlNameSanitizationFallback() {
         Node doc = new Node(List.of(new Edge("123", new StringScalar("v"))));
-        String xml = XmlCodec.write(doc);
-        assertTrue(xml.contains("<_123>") || xml.contains("<_"));
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(doc));
+        assertTrue(ex.report().adjustments().stream()
+            .anyMatch(a -> a.code().equals("write.unsupported-value")));
     }
 
     @Test
@@ -383,28 +408,22 @@ public class XmlCodecTest {
     }
 
     @Test
-    @DisplayName("write: strict mode succeeds with no adjustments, and xmlName's fully-sanitized-to-empty fallback")
+    @DisplayName("write: strict mode succeeds with no adjustments; an invalid label (digit-led or empty) fails unconditionally either way (issue #88)")
     void testWriteStrictSucceedsAndXmlNameEmptyFallback() {
         Node cleanDoc = new Node(List.of(new Edge("root", new StringScalar("v"))));
         String xml = XmlCodec.write(cleanDoc, true, null);
         assertTrue(xml.contains("<root>"));
 
-        // "123" sanitizes to itself (digits are XML_NAME-legal characters) but
-        // still fails XML_NAME's own match (a name can't start with a digit),
-        // forcing the "_" prefix fallback -- distinct from a label whose
-        // sanitized form is empty.
+        // "123" isn't a valid XML name (a name can't start with a digit) -- issue #88
+        // means this now fails unconditionally, with no "_" prefix sanitize fallback.
         Node digitLabel = new Node(List.of(new Edge("123", new StringScalar("v"))));
-        String xml2 = XmlCodec.write(digitLabel);
-        assertTrue(xml2.contains("<_123"));
+        WriteException ex1 = assertThrows(WriteException.class, () -> XmlCodec.write(digitLabel));
+        assertTrue(ex1.report().adjustments().stream().anyMatch(a -> a.code().equals("write.unsupported-value")));
 
-        // An empty label: replaceAll can never shrink a non-empty string to
-        // empty (it's a 1:1 char substitution), so safe.isEmpty() can only be
-        // true when the original label was itself empty -- xmlName's isEmpty()
-        // short-circuit, distinct from the "123" case above (non-empty but
-        // XML_NAME-non-matching).
+        // An empty label is likewise not a valid XML name -- also fails unconditionally.
         Node emptyLabel = new Node(List.of(new Edge("", new StringScalar("v"))));
-        String xml3 = XmlCodec.write(emptyLabel);
-        assertTrue(xml3.contains("<_>") || xml3.contains("<_ "));
+        WriteException ex2 = assertThrows(WriteException.class, () -> XmlCodec.write(emptyLabel));
+        assertTrue(ex2.report().adjustments().stream().anyMatch(a -> a.code().equals("write.unsupported-value")));
     }
 
     @Test
@@ -422,14 +441,18 @@ public class XmlCodecTest {
         assertEquals("root", roundNode.edges().get(0).label());
         assertEquals("<admin>true</admin>", ((StringScalar) roundNode.edges().get(0).target()).value());
 
-        // Adversarial metacharacters roundtrip
-        String adversarial = "<>&\"'\u0000\t\n<&amp;>";
+        // Adversarial metacharacters that ARE representable still roundtrip fine.
+        String adversarial = "<>&\"'\t\n<&amp;>";
         Node advDoc = new Node(List.of(new Edge("root", new StringScalar(adversarial))));
         String advXml = XmlCodec.write(advDoc);
         Document advRound = XmlCodec.read(advXml);
-        // Note: \u0000 is replaced by \uFFFD by xmlSanitize
-        String expected = "<>&\"'\uFFFD\t\n<&amp;>";
-        assertEquals(expected, ((StringScalar) ((Node) advRound).edges().get(0).target()).value());
+        assertEquals(adversarial, ((StringScalar) ((Node) advRound).edges().get(0).target()).value());
+
+        // \u0000 is a character XML 1.0 cannot represent at all -- fails unconditionally
+        // now (issue #88), rather than being silently substituted with U+FFFD.
+        Node illegalDoc = new Node(List.of(new Edge("root", new StringScalar("a\u0000b"))));
+        WriteException ex = assertThrows(WriteException.class, () -> XmlCodec.write(illegalDoc));
+        assertTrue(ex.report().adjustments().stream().anyMatch(a -> a.code().equals("write.unsupported-value")));
     }
 
     @Test

--- a/src/test/java/dev/omnist/conformance/ConformanceTest.java
+++ b/src/test/java/dev/omnist/conformance/ConformanceTest.java
@@ -40,8 +40,8 @@ class ConformanceTest {
         // all 17 new conformance vectors for that batch at once, but the fixes land one PR
         // at a time. 15 vectors fail until the last PR in the batch (#91) lands; restore
         // these to 172/0/0 there.
-        assertEquals(167, results[0], "Track 2 should pass 167 of 172 real JSON test vectors during the #87-95 batch");
-        assertEquals(5, results[1], "Track 2 should have 5 known failures pending #88-90 (fail-dont-invent) and #91 (XML CR escaping)");
+        assertEquals(171, results[0], "Track 2 should pass 171 of 172 real JSON test vectors during the #87-95 batch");
+        assertEquals(1, results[1], "Track 2 should have 1 known failure pending #91 (XML CR escaping), the last PR in this batch");
         assertEquals(0, results[2], "Track 2 should have 0 skips");
     }
 


### PR DESCRIPTION
Per omnist-spec section 8.3.8/8.3.9, writing a value a target format's own syntax cannot represent at all -- or that would collide, on read-back, with a genuinely different, independently-valid input -- now MUST fail unconditionally with `write.unsupported-value`, regardless of `strict`. Three prior "sanitize/drop/substitute and warn, write succeeds" behaviors are removed for exactly this reason:

- **XML** (#88): a label or character its own syntax cannot represent. Two different labels can sanitize to the same XML name (e.g. `"my label"` and `"my_label"` both -> `<my_label>`), silently producing a Document on read-back that looks like one label legitimately repeated twice, with no diagnostic anywhere indicating a collision. Removes `format.key-sanitized` and `format.string-illegal-char`.
- **TOML/XML** (#89): a null-valued leaf written to a format with no null token. Silently dropping the edge doesn't just alter what's represented at that position, it erases the edge's existence entirely. Removes `format.null-unrepresentable`.
- **JSON/XML** (#90): NaN/Infinity (no JSON token for either); an empty internal node in XML (indistinguishable from an empty string leaf on read-back). A genuine `null` and a substituted `NaN` both produce the identical JSON `null` token. Removes `format.float-special` and `format.shape-empty-ambiguous`.

**Not affected, deliberately**: `format.value-stringified`, `format.temporal-stringified`, and `format.string-cr-normalized` (the last one gets its own real fix, not a failure, in the next PR) have the same collision shape but are unavoidable for every typed scalar a typeless format writes -- failing there would disable the format for ordinary use.

Also removed `XmlCodec.xmlName`'s sanitize-fallback and `xmlSanitize`'s U+FFFD substitution outright (now unreachable -- `write()` always fails first -- so no fallback nobody can reach). `writeNode`'s empty-internal-node self-closing branch and `prepareJson`'s NaN/Infinity-to-null branch are likewise unreachable but kept with confirmed-unreachable comments (same convention as the LINE gate's existing dead lines, since they remain structurally necessary for the type signature). BRANCH coverage gate adjusted (0.993 -> 0.991).

Grepped this codebase's own tests for anything asserting the old lenient behavior and updated each one (`XmlCodecTest`, `JsonCodecTest`, `TomlCodecTest`, `GapCoverageTest`, `FinalCoverageTest`) to expect the new unconditional failure instead of deleting them. Two tests that exercised the (now unconditional-failing) strict-only throw path via a null edge were changed to use a still-warning-only adjustment instead, so that path stays covered.

## Conformance
`formats-xml/basic/label-with-illegal-xml-characters-cannot-be-written`, `formats-toml/nulls/null-leaf-cannot-be-written` (+ `...-strict-is-the-same`), `formats-json/basic/nan-cannot-be-written`, and `formats-xml/basic/empty-internal-node-cannot-be-written` all pass.

Part of the #87-95 batch (see #96); only 1 of the 17 new conformance vectors remains pending (issue #91, the next and final PR), tracked via `ConformanceTest`'s counts (171/1/0 of 172).

`mvn clean test`: 611 tests, 0 failures, all coverage gates met.

Closes #88
Closes #89
Closes #90
