### PR TITLE
XML: escape carriage returns as &#13; instead of writing them raw; bump 0.2.2-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ Available on [Maven Central](https://central.sonatype.com/artifact/dev.omnist/om
 <dependency>
     <groupId>dev.omnist</groupId>
     <artifactId>omnist-j</artifactId>
-    <version>0.2.1-alpha</version>
+    <version>0.2.2-alpha</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation 'dev.omnist:omnist-j:0.2.1-alpha'
+implementation 'dev.omnist:omnist-j:0.2.2-alpha'
 ```
 
 This is a plain library jar with its real dependencies (Jackson, SnakeYAML, tomlj) resolved normally — nothing bundled or shaded. If you want to run `omnist` as a standalone CLI instead of using it as a library, use the `cli` classifier, which is a self-contained fat jar:
 ```bash
-curl -O https://repo1.maven.org/maven2/dev/omnist/omnist-j/0.2.1-alpha/omnist-j-0.2.1-alpha-cli.jar
-java -jar omnist-j-0.2.1-alpha-cli.jar format sample.oml --to json
+curl -O https://repo1.maven.org/maven2/dev/omnist/omnist-j/0.2.2-alpha/omnist-j-0.2.2-alpha-cli.jar
+java -jar omnist-j-0.2.2-alpha-cli.jar format sample.oml --to json
 ```
 
 ## Quickstart
@@ -91,7 +91,7 @@ See [`docs/02-cli-reference.md`](docs/02-cli-reference.md) for every subcommand.
 
 ## Status
 
-**`v0.2.1-alpha`** — spec-first, built directly against [`vendor/omnist-spec`](https://github.com/omnist-dev/omnist-spec) (pinned as a git submodule, the normative source of truth for this port's behavior).
+**`v0.2.2-alpha`** — spec-first, built directly against [`vendor/omnist-spec`](https://github.com/omnist-dev/omnist-spec) (pinned as a git submodule, the normative source of truth for this port's behavior).
 
 - **Conformance**: 182/182 (100%) passing against the shared spec test suite, across CLI fixtures and JSON test vectors.
 - **Tests**: 584 passing, 0 failures — JUnit plus jqwik property-based and fuzz testing.

--- a/docs/02-cli-reference.md
+++ b/docs/02-cli-reference.md
@@ -9,7 +9,7 @@
 The CLI executable fat jar can be invoked via:
 
 ```bash
-java -jar target/omnist-j-0.2.1-alpha.jar <command> [subcommand] [options]
+java -jar target/omnist-j-0.2.2-alpha.jar <command> [subcommand] [options]
 ```
 
 Or via `./run-conformance` / shell wrapper `omnist`:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Status and limitations
 
-**`v0.2.1-alpha`.** `omnist-j` implements the full Document model, Schema model, OML and OSD
+**`v0.2.2-alpha`.** `omnist-j` implements the full Document model, Schema model, OML and OSD
 grammars (read and write), `validate`, `materialize`, the full schema
 algebra (`satisfiable_set`, `is_empty`, `prune`, `compatible_with`,
 `equivalent`, `normalize`, `extract`, `lint`, `infer`), all four

--- a/docs/workflow-playbook.md
+++ b/docs/workflow-playbook.md
@@ -218,7 +218,7 @@ If a change touches a public API surface, a documented number, or an external-st
 
 **Artifact shape**: the main `dev.omnist:omnist-j` jar is a plain library jar with its real `<dependencies>` intact (Jackson/SnakeYAML/tomlj resolve normally for anyone adding it as a dependency). The shaded fat jar for running `omnist` as a standalone CLI is a separate `-cli` classifier (`omnist-j-<version>-cli.jar`), attached by the same `maven-shade-plugin` execution but never replacing the main artifact. The `omnist` wrapper script and `Track1Runner.java`'s conformance harness both reference the `-cli.jar` explicitly — if either the shade plugin's classifier name or the version changes, update both call sites in the same commit (see §8 above).
 
-**Releasing is automated via `.github/workflows/release.yml`**, triggered by pushing a `v*` tag (e.g. `v0.2.1-alpha`). It runs as two jobs:
+**Releasing is automated via `.github/workflows/release.yml`**, triggered by pushing a `v*` tag (e.g. `v0.2.2-alpha`). It runs as two jobs:
 1. `verify` — the same `mvn clean test` + `./run-conformance` gates as regular CI, plus a check that the pushed tag's version actually matches `pom.xml`'s `<version>` (fails loudly if they've drifted, rather than publishing the wrong content under the wrong tag).
 2. `publish` — gated behind the `central-publish` GitHub Environment, runs `mvn clean deploy -Prelease` using secrets for the GPG key and Central Portal credentials.
 

--- a/omnist
+++ b/omnist
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # wrapper script for omnist-j CLI
-exec java -jar "$(dirname "$0")/target/omnist-j-0.2.1-alpha-cli.jar" "$@"
+exec java -jar "$(dirname "$0")/target/omnist-j-0.2.2-alpha-cli.jar" "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.omnist</groupId>
     <artifactId>omnist-j</artifactId>
-    <version>0.2.1-alpha</version>
+    <version>0.2.2-alpha</version>
     <name>omnist-j</name>
     <description>Java implementation of the Omnist data-interchange specification</description>
     <url>https://j.omnist.dev</url>

--- a/src/main/java/dev/omnist/codec/XmlCodec.java
+++ b/src/main/java/dev/omnist/codec/XmlCodec.java
@@ -443,6 +443,11 @@ public final class XmlCodec {
      * first and fails unconditionally (issue #88) on any character XML 1.0 cannot
      * represent, so no U+FFFD substitution is needed here anymore -- this is reached
      * only with already-legal XML character data.
+     *
+     * <p>A literal carriage return is escaped as the numeric character reference
+     * {@code &#13;} (issue #91): XML mandates line-ending normalization on parse, so a
+     * raw '\r' and a raw '\n' are indistinguishable on read-back, but a numeric character
+     * reference is exempt from that normalization and survives a compliant parser intact.
      */
     private static String xmlSanitize(String text) {
         StringBuilder sb = new StringBuilder(text.length() + 16);
@@ -454,6 +459,7 @@ public final class XmlCodec {
                 case '>' -> sb.append("&gt;");
                 case '"' -> sb.append("&quot;");
                 case '\'' -> sb.append("&apos;");
+                case '\r' -> sb.append("&#13;");
                 default -> sb.append(c);
             }
         }
@@ -569,13 +575,9 @@ public final class XmlCodec {
                         "(e.g. a C0 control other than tab/LF/CR)",
                         "error");
             }
-            if (strVal.contains("\r")) {
-                rep.add(path, "format.string-cr-normalized",
-                        "string contains a carriage return ('\\r'); XML mandates " +
-                        "line-ending normalization on parse, so '\\r' (and '\\r\\n') " +
-                        "read back as '\\n'",
-                        "warning");
-            }
+            // Issue #91: a carriage return is now escaped losslessly as the numeric
+            // character reference &#13; (see xmlSanitize) instead of being written raw
+            // and warned about -- nothing to report here anymore.
         }
     }
 }

--- a/src/main/java/dev/omnist/conformance/Track1Runner.java
+++ b/src/main/java/dev/omnist/conformance/Track1Runner.java
@@ -244,7 +244,7 @@ public final class Track1Runner {
             String stderr = "";
             int exitCode = -1;
 
-            Path omnistJar = repoDir.resolve("target/omnist-j-0.2.1-alpha-cli.jar");
+            Path omnistJar = repoDir.resolve("target/omnist-j-0.2.2-alpha-cli.jar");
             Path omnistBin = repoDir.resolve("omnist");
             if (Files.exists(omnistJar) && Files.exists(omnistBin) && Files.isExecutable(omnistBin)) {
                 try {

--- a/src/test/java/dev/omnist/FinalCoverageTest.java
+++ b/src/test/java/dev/omnist/FinalCoverageTest.java
@@ -1035,17 +1035,16 @@ class FinalCoverageTest {
 
     @Test
     void xmlCodec_crInStringWarning() {
-        // scanXml: strVal.contains(\r) -> format.string-cr-normalized
+        // xmlSanitize: \r escaped losslessly as &#13; -- no diagnostic anymore (issue #91)
         Node doc = new Node(List.of(
             new Edge("root", new Node(List.of(
                 new Edge("s", new StringScalar("line1\r\nline2"))
             )))
         ));
         WriteReport rep = new WriteReport();
-        XmlCodec.write(doc, false, rep);
-        assertTrue(rep.adjustments().stream()
-            .anyMatch(a -> a.code().equals("format.string-cr-normalized")),
-            "Expected cr-normalized warning");
+        String xml = XmlCodec.write(doc, false, rep);
+        assertTrue(xml.contains("line1&#13;\nline2"), "Expected &#13; escape in: " + xml);
+        assertTrue(rep.adjustments().isEmpty());
     }
 
     @Test

--- a/src/test/java/dev/omnist/codec/XmlCodecTest.java
+++ b/src/test/java/dev/omnist/codec/XmlCodecTest.java
@@ -111,8 +111,8 @@ public class XmlCodecTest {
     }
 
     @Test
-    @DisplayName("write records a warning for a stringified non-string scalar and a CR (unaffected by the fail-dont-invent fixes here)")
-    void testWriteValueStringifiedAndCrWarnings() {
+    @DisplayName("write records a warning for a stringified non-string scalar; a CR is escaped losslessly, not warned about (issue #91)")
+    void testWriteValueStringifiedAndCrEscaping() {
         Node child = new Node(List.of(
             new Edge("bool", new BooleanScalar(true)),
             new Edge("int", new IntegerScalar(BigInteger.TEN)),
@@ -123,10 +123,25 @@ public class XmlCodecTest {
         WriteReport report = new WriteReport();
         String xml = XmlCodec.write(root, false, report);
         assertTrue(xml.contains("<root>"));
+        assertTrue(xml.contains("line1&#13;line2"), "Expected &#13; escape in: " + xml);
 
         List<WriteAdjustment> adjs = report.adjustments();
         assertTrue(adjs.stream().anyMatch(a -> a.code().equals("format.value-stringified")));
-        assertTrue(adjs.stream().anyMatch(a -> a.code().equals("format.string-cr-normalized")));
+        assertTrue(adjs.stream().noneMatch(a -> a.code().equals("format.string-cr-normalized")));
+    }
+
+    @Test
+    @DisplayName("carriage return written as numeric character reference (issue #91, happy path)")
+    void testCarriageReturnEscapedAsNumericCharacterReference() {
+        Node root = new Node(List.of(new Edge("root", new Node(List.of(new Edge("x", new StringScalar("a\rb")))))));
+        WriteReport report = new WriteReport();
+        String xml = XmlCodec.write(root, false, report);
+        assertEquals("<root>\n  <x>a&#13;b</x>\n</root>\n", xml);
+        assertTrue(report.adjustments().isEmpty());
+
+        Node crlf = new Node(List.of(new Edge("root", new Node(List.of(new Edge("x", new StringScalar("a\r\nb")))))));
+        String xmlCrlf = XmlCodec.write(crlf, false, new WriteReport());
+        assertEquals("<root>\n  <x>a&#13;\nb</x>\n</root>\n", xmlCrlf);
     }
 
     @Test

--- a/src/test/java/dev/omnist/conformance/ConformanceTest.java
+++ b/src/test/java/dev/omnist/conformance/ConformanceTest.java
@@ -34,14 +34,10 @@ class ConformanceTest {
         int[] results = Track2Runner.runTrack2(testSuitePath);
         assertNotNull(results);
         assertEquals(3, results.length);
-        // TEMPORARY during the #87-95 batch: the omnist-spec submodule pin was bumped
-        // ahead of time (per issue #87's own instructions, to avoid landing on an
-        // intermediate commit that contradicts the new [0,0]-cardinality rule) to bring in
-        // all 17 new conformance vectors for that batch at once, but the fixes land one PR
-        // at a time. 15 vectors fail until the last PR in the batch (#91) lands; restore
-        // these to 172/0/0 there.
-        assertEquals(171, results[0], "Track 2 should pass 171 of 172 real JSON test vectors during the #87-95 batch");
-        assertEquals(1, results[1], "Track 2 should have 1 known failure pending #91 (XML CR escaping), the last PR in this batch");
+        // Restored to full-pass in this PR, which closes out the #87-95 batch (all 17
+        // new conformance vectors for that batch, plus the 155 pre-existing ones, now pass).
+        assertEquals(172, results[0], "Track 2 should pass all 172 real JSON test vectors");
+        assertEquals(0, results[1], "Track 2 should have 0 failures");
         assertEquals(0, results[2], "Track 2 should have 0 skips");
     }
 


### PR DESCRIPTION
Per omnist-spec section 8.3.8, writing a string containing `\r` to XML now escapes it as the numeric character reference `&#13;` (and `\r\n` as `&#13;\n`), instead of writing it raw. XML mandates line-ending normalization on parse, so a literal `\r` and a literal `\n` are otherwise indistinguishable on read-back -- the same collision shape as the other five fixes in this series -- but unlike those, a real lossless representation exists here: a numeric character reference is exempt from that normalization and survives a compliant parser intact.

Removes the `format.string-cr-normalized` diagnostic entirely -- the write is now genuinely lossless, nothing left to report.

## This is the last PR in the #87-95 batch

Bumping the `vendor/omnist-spec` submodule pin (done in #96) surfaced all 17 new conformance vectors for the batch at once, and this PR's fix is the last of the 9 issues to land, so `ConformanceTest`'s counts are restored here to a full pass (172/172, 0 failures) instead of the temporary reduced-pass counts carried by the 4 prior PRs in this batch.

Also bumps `pom.xml`'s version `0.2.1-alpha` -> `0.2.2-alpha` (real behavior changes across 9 issues since 0.2.1-alpha; patch bump per this repo's own convention for a batch of fixes, not new features -- see the `0.2.0-alpha` -> `0.2.1-alpha` precedent in #76). Updated all 7 known version-string locations and grepped the exact old string across the repo to confirm zero remaining matches.

## Conformance
`formats-xml/basic/carriage-return-written-as-numeric-character-reference` passes (happy path, not an error case) -- writing `"a\rb"` produces exactly `<root>\n  <x>a&#13;b</x>\n</root>\n`.

Full harness: **201/201, 0 failures, 0 skips.** `mvn clean test`: 612 tests, 0 failures, all coverage gates met.

Closes #91
